### PR TITLE
NR_REG_SINGLE_RX: single RX queue mode support

### DIFF
--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -3094,7 +3094,7 @@ netmap_reset(struct netmap_adapter *na, enum txrx tx, u_int n,
  * - for a nic connected to a switch, call the proper forwarding routine
  *   (see netmap_bwrap_intr_notify)
  */
-void
+int
 netmap_common_irq(struct netmap_adapter *na, u_int q, u_int *work_done)
 {
 	struct netmap_kring *kring;
@@ -3107,7 +3107,7 @@ netmap_common_irq(struct netmap_adapter *na, u_int q, u_int *work_done)
 	}
 
 	if (q >= nma_get_nrings(na, t))
-		return;	// not a physical queue
+		return 0; // not a physical queue
 
 	kring = NMR(na, t) + q;
 
@@ -3116,6 +3116,7 @@ netmap_common_irq(struct netmap_adapter *na, u_int q, u_int *work_done)
 		*work_done = 1; /* do not fire napi again */
 	}
 	kring->nm_notify(kring, 0);
+	return 1;
 }
 
 
@@ -3154,8 +3155,7 @@ netmap_rx_irq(struct ifnet *ifp, u_int q, u_int *work_done)
 		return 0;
 	}
 
-	netmap_common_irq(na, q, work_done);
-	return 1;
+	return netmap_common_irq(na, q, work_done);
 }
 
 

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -1730,6 +1730,12 @@ netmap_interp_ringid(struct netmap_priv_d *priv, uint16_t ringid, uint32_t flags
 	case NR_REG_PIPE_MASTER:
 	case NR_REG_PIPE_SLAVE:
 		for_rx_tx(t) {
+			if ((t == NR_RX && (flags & NR_TX_RINGS_ONLY)) ||
+			    (t == NR_TX && (flags & NR_RX_RINGS_ONLY))) {
+				priv->np_qfirst[t] = priv->np_qlast[t] = 0;
+				continue;
+			}
+
 			priv->np_qfirst[t] = 0;
 			priv->np_qlast[t] = nma_get_nrings(na, t);
 		}
@@ -1743,6 +1749,18 @@ netmap_interp_ringid(struct netmap_priv_d *priv, uint16_t ringid, uint32_t flags
 			return EINVAL;
 		}
 		for_rx_tx(t) {
+			if ((t == NR_RX && (flags & NR_TX_RINGS_ONLY)) ||
+			    (t == NR_TX && (flags & NR_RX_RINGS_ONLY))) {
+				/*
+				 * NR_[TX|RX]_RINGS_ONLY affects only hw
+				 * rings, so keep sw rings on in any
+				 * case
+				 */
+				priv->np_qfirst[t] = nma_get_nrings(na, t);
+				priv->np_qlast[t] = nma_get_nrings(na, t) + 1;
+				continue;
+			}
+
 			priv->np_qfirst[t] = (reg == NR_REG_SW ?
 				nma_get_nrings(na, t) : 0);
 			priv->np_qlast[t] = nma_get_nrings(na, t) + 1;
@@ -1756,6 +1774,12 @@ netmap_interp_ringid(struct netmap_priv_d *priv, uint16_t ringid, uint32_t flags
 			return EINVAL;
 		}
 		for_rx_tx(t) {
+			if ((t == NR_RX && (flags & NR_TX_RINGS_ONLY)) ||
+			    (t == NR_TX && (flags & NR_RX_RINGS_ONLY))) {
+				priv->np_qfirst[t] = priv->np_qlast[t] = 0;
+				continue;
+			}
+
 			/* if not enough rings, use the first one */
 			j = i;
 			if (j >= nma_get_nrings(na, t))

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -815,6 +815,8 @@ netmap_krings_create(struct netmap_adapter *na, u_int tailroom)
 			kring->ring_id = i;
 			kring->tx = t;
 			kring->nkr_num_slots = ndesc;
+			kring->nr_mode = NKR_NETMAP_OFF;
+			kring->nr_pending_mode = NKR_NETMAP_OFF;
 			if (i < nma_get_nrings(na, t)) {
 				kring->nm_sync = (t == NR_TX ? na->nm_txsync : na->nm_rxsync);
 			} else {
@@ -909,11 +911,20 @@ static void
 netmap_do_unregif(struct netmap_priv_d *priv)
 {
 	struct netmap_adapter *na = priv->np_na;
+	enum txrx t;
+	int i;
 
 	NMG_LOCK_ASSERT();
 	na->active_fds--;
 	/* release exclusive use if it was requested on regif */
 	netmap_rel_exclusive(priv);
+
+	for_rx_tx(t) {
+		for (i = priv->np_qfirst[t]; i < priv->np_qlast[t]; i++) {
+			kring_rel_netmap_mode(priv, t, i);
+		}
+	}
+
 	if (na->active_fds <= 0) {	/* last instance */
 
 		if (netmap_verbose)
@@ -948,6 +959,10 @@ netmap_do_unregif(struct netmap_priv_d *priv)
 		/* delete rings and buffers */
 		netmap_mem_rings_delete(na);
 		na->nm_krings_delete(na);
+	} else {
+		if (kring_pending(priv)) {
+			na->nm_register(na, 1);
+		}
 	}
 	/* possibily decrement counter of tx_si/rx_si users */
 	netmap_unset_ringid(priv);
@@ -1971,6 +1986,8 @@ netmap_do_regif(struct netmap_priv_d *priv, struct netmap_adapter *na,
 {
 	struct netmap_if *nifp = NULL;
 	int error;
+	enum txrx t;
+	int i;
 
 	NMG_LOCK_ASSERT();
 	/* ring configuration may have changed, fetch from the card */
@@ -2011,6 +2028,12 @@ netmap_do_regif(struct netmap_priv_d *priv, struct netmap_adapter *na,
 	if (error)
 		goto err_del_rings;
 
+	for_rx_tx(t) {
+		for (i = priv->np_qfirst[t]; i < priv->np_qlast[t]; i++) {
+			kring_get_netmap_mode(priv, t, i);
+		}
+	}
+
 	/* in all cases, create a new netmap if */
 	nifp = netmap_mem_if_new(na);
 	if (nifp == NULL) {
@@ -2032,6 +2055,10 @@ netmap_do_regif(struct netmap_priv_d *priv, struct netmap_adapter *na,
 		error = na->nm_register(na, 1); /* mode on */
 		if (error) 
 			goto err_del_if;
+	} else {
+		if (kring_pending(priv)) {
+			na->nm_register(na, 1);
+		}
 	}
 
 	/*
@@ -2050,6 +2077,12 @@ err_del_if:
 	netmap_mem_if_delete(na, nifp);
 err_rel_excl:
 	netmap_rel_exclusive(priv);
+
+	for_rx_tx(t) {
+		for (i = priv->np_qfirst[t]; i < priv->np_qlast[t]; i++) {
+			kring_rel_netmap_mode(priv, t, i);
+		}
+	}
 err_del_rings:
 	if (na->active_fds == 0)
 		netmap_mem_rings_delete(na);
@@ -2940,11 +2973,12 @@ int
 netmap_transmit(struct ifnet *ifp, struct mbuf *m)
 {
 	struct netmap_adapter *na = NA(ifp);
-	struct netmap_kring *kring;
+	struct netmap_kring *kring, *tx_kring;
 	u_int len = MBUF_LEN(m);
 	u_int error = ENOBUFS;
 	struct mbq *q;
 	int space;
+	int txr;
 
 	kring = &na->rx_rings[na->num_rx_rings];
 	// XXX [Linux] we do not need this lock
@@ -2956,6 +2990,23 @@ netmap_transmit(struct ifnet *ifp, struct mbuf *m)
 		error = ENXIO;
 		goto done;
 	}
+
+#if defined (__FreeBSD__)
+	txr = m->m_pkthdr.flowid;
+	tx_kring = &NMR(na, NR_TX)[txr];
+
+	if (tx_kring->nr_mode == NKR_NETMAP_OFF) {
+		return na->if_transmit(ifp, m);
+	}
+
+#elif defined (linux)
+	txr = m->queue_mapping;
+	tx_kring = &NMR(na, NR_TX)[txr];
+
+	if (tx_kring->nr_mode == NKR_NETMAP_OFF) {
+		return ((struct net_device_ops *) na->if_transmit)->ndo_start_xmit(m, ifp);
+	}
+#endif
 
 	q = &kring->rx_queue;
 
@@ -3032,13 +3083,26 @@ netmap_reset(struct netmap_adapter *na, enum txrx tx, u_int n,
 	if (tx == NR_TX) {
 		if (n >= na->num_tx_rings)
 			return NULL;
+
 		kring = na->tx_rings + n;
+
+		if (kring->nr_pending_mode == NKR_NETMAP_OFF) {
+			kring->nr_mode = NKR_NETMAP_OFF;
+			return NULL;
+		}
+
 		// XXX check whether we should use hwcur or rcur
 		new_hwofs = kring->nr_hwcur - new_cur;
 	} else {
 		if (n >= na->num_rx_rings)
 			return NULL;
 		kring = na->rx_rings + n;
+
+		if (kring->nr_pending_mode == NKR_NETMAP_OFF) {
+			kring->nr_mode = NKR_NETMAP_OFF;
+			return NULL;
+		}
+
 		new_hwofs = kring->nr_hwtail - new_cur;
 	}
 	lim = kring->nkr_num_slots - 1;
@@ -3075,6 +3139,7 @@ netmap_reset(struct netmap_adapter *na, enum txrx tx, u_int n,
 	 * We do the wakeup here, but the ring is not yet reconfigured.
 	 * However, we are under lock so there are no races.
 	 */
+	kring->nr_mode = NKR_NETMAP_ON;
 	kring->nm_notify(kring, 0);
 	return kring->ring->slot;
 }
@@ -3111,10 +3176,15 @@ netmap_common_irq(struct netmap_adapter *na, u_int q, u_int *work_done)
 
 	kring = NMR(na, t) + q;
 
+	if (kring->nr_mode == NKR_NETMAP_OFF) {
+		return 0;
+	}
+
 	if (t == NR_RX) {
 		kring->nr_kflags |= NKR_PENDINTR;	// XXX atomic ?
 		*work_done = 1; /* do not fire napi again */
 	}
+
 	kring->nm_notify(kring, 0);
 	return 1;
 }

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -1111,7 +1111,7 @@ int netmap_ring_reinit(struct netmap_kring *);
 /* default functions to handle rx/tx interrupts */
 int netmap_rx_irq(struct ifnet *, u_int, u_int *);
 #define netmap_tx_irq(_n, _q) netmap_rx_irq(_n, _q, NULL)
-void netmap_common_irq(struct netmap_adapter *, u_int, u_int *work_done);
+int netmap_common_irq(struct netmap_adapter *, u_int, u_int *work_done);
 
 
 #ifdef WITH_VALE

--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -532,6 +532,8 @@ enum {	NR_REG_DEFAULT	= 0,	/* backward compat, should not be used. */
 /* request ptnetmap host support */
 #define NR_PASSTHROUGH_HOST	NR_PTNETMAP_HOST /* deprecated */
 #define NR_PTNETMAP_HOST	0x1000
+#define NR_RX_RINGS_ONLY	0x2000
+#define NR_TX_RINGS_ONLY	0x4000
 
 
 /*

--- a/sys/net/netmap_user.h
+++ b/sys/net/netmap_user.h
@@ -313,6 +313,8 @@ typedef void (*nm_cb_t)(u_char *, const struct nm_pkthdr *, const u_char *d);
  *		z		zero copy monitor
  *		t		monitor tx side
  *		r		monitor rx side
+ *		R		bind only RX ring(s)
+ *		T		bind only TX ring(s)
  *
  * req		provides the initial values of nmreq before parsing ifname.
  *		Remember that the ifname parsing will override the ring
@@ -700,6 +702,12 @@ nm_open(const char *ifname, const struct nmreq *req,
 				break;
 			case 'r':
 				nr_flags |= NR_MONITOR_RX;
+				break;
+			case 'R':
+				nr_flags |= NR_RX_RINGS_ONLY;
+				break;
+			case 'T':
+				nr_flags |= NR_TX_RINGS_ONLY;
 				break;
 			default:
 				snprintf(errmsg, MAXERRMSG, "unrecognized flag: '%c'", *port);


### PR DESCRIPTION
In current modes (`NR_REG_ONE_NIC`, `NR_REG_ALL_NIC`) Netmap takes over all RX queues.
For some applications this is undesirable: the user might want to enable Netmap only on a single RX queue and leave the rest untouched (i.e. all packets flowing to other queues are handled as usual: pushed to the kernel without any Netmap interference).

This patch introduces support for a new mode called single RX queue (`NR_REG_SINGLE_RX`), in which an adapter exposes only the requested RX rings to the Netmap applications.
All the other RX queues are kept attached to the host stack, thus keeping all the network flows working as usual. The TX side is as well managed by the kernel, untouched by Netmap.

This mode can be useful for applications receiving packets at high speed, when it's not affordable to put an entire NIC in Netmap mode. We believe this approach avoids the cost and complexity of the transparent mode.

An example use would look like:

* With an indirection table manipulation user isolates one RX queue from normal network traffic.
* User adds a dedicated flow steering rule to direct only a specific network flow to the isolated RX queue.
* User opens an interface in `NR_REG_SINGLE_RX` mode on the isolated queue and is able to receive packets at high speed using a well defined Netmap APIs.
* All other network flows going to the kernel are uninterrupted and do not need any support from the Netmap application.

For ease of use we propose the following syntax support for the single rx queue mode in the netmap_user.h helpers (X is the RX queue number):

```c
nm_open("netmap:ifN~X", NULL, 0, 0)
````

It's worth noting three quirks:
* The transmission side is not handled by this patch. It is not possible to access the TX ring from the application that has opened the interface in `NR_REG_SINGLE_RX` mode.
* While in `NR_REG_SINGLE_RX` mode, the adapter cannot be reopened in a different mode, and viceversa, while already opened in a different mode, the adaptor cannot be reopened in `NR_REG_SINGLE_RX` mode. 
* Some hardware RX queues are special. For example ARP packets are often pushed to RX queue #0. Applications using single RX mode with RX queue #0 might need to handle ARP protocol.