### PR TITLE
NETMAP_BDG_LIST bug

### DIFF
--- a/examples/vale-ctl.c
+++ b/examples/vale-ctl.c
@@ -143,10 +143,13 @@ bdg_ctl(const char *name, int nr_cmd, int nr_arg, char *nmr_config)
 
 		/* scan all the bridges and ports */
 		nmr.nr_arg1 = nmr.nr_arg2 = 0;
-		for (; !ioctl(fd, NIOCGINFO, &nmr); nmr.nr_arg2++) {
-			D("bridge:%d port:%d %s", nmr.nr_arg1, nmr.nr_arg2,
-			    nmr.nr_name);
-			nmr.nr_name[0] = '\0';
+		for (uint16_t nth_bridge = nmr.nr_arg1, nth_port = nmr.nr_arg2;
+				ioctl(fd, NIOCGINFO, &nmr) != 0;
+				nmr.nr_arg2 = nth_port, nmr.nr_name[0] = '\0') {
+			D("bridge:%d port:%d %s", nmr.nr_arg1, nmr.nr_arg2, nmr.nr_name);
+
+			nth_port = (nmr.nr_arg1 != nth_bridge) ? nmr.nr_arg2+1 : nth_port+1;
+			nth_bridge = nmr.nr_arg1;
 		}
 
 		break;

--- a/sys/dev/netmap/netmap_vale.c
+++ b/sys/dev/netmap/netmap_vale.c
@@ -1169,8 +1169,8 @@ netmap_bdg_ctl(struct nmreq *nmr, struct netmap_bdg_ops *bdg_ops)
 					continue;
 				}
 				nmr->nr_arg1 = i;
-				nmr->nr_arg2 = j;
 				j = b->bdg_port_index[j];
+				nmr->nr_arg2 = j;
 				vpna = b->bdg_ports[j];
 				strncpy(name, vpna->up.name, (size_t)IFNAMSIZ);
 				error = 0;


### PR DESCRIPTION
When listing all bridge/port with `vale-ctl`, the port column is not the port number, it's the index of the port number in the **bdg_port_index** in the kernel. Port number is not written into **nr_arg2** correctly in kernel code.
