### PR TITLE
netmap_mem_global_finalize: fix bug triggered in error case

### DIFF
--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -1628,7 +1628,7 @@ netmap_mem_global_finalize(struct netmap_mem_d *nmd)
 
 	/* update configuration if changed */
 	if (netmap_mem_global_config(nmd))
-		goto out;
+		return nmd->lasterr;
 
 	nmd->active++;
 


### PR DESCRIPTION
If netmap_mem_global_config function failed and set nmd->lasterr
then nmd->active will be decremented.