### PR TITLE
Fix #177: give drivers their requested headroom.

### DIFF
--- a/LINUX/bsd_glue.h
+++ b/LINUX/bsd_glue.h
@@ -191,7 +191,11 @@ struct thread;
 #define m_freem(m)		dev_kfree_skb_any(m)	// free a sk_buff
 
 #define MBUF_REFCNT(m)			NM_ATOMIC_READ(&((m)->users))
-#define nm_os_get_mbuf(ifp, size)	alloc_skb(size, GFP_ATOMIC)
+static inline struct mbuf *nm_os_get_mbuf(struct net_device *ifp, int len)
+{
+    len += LL_RESERVED_SPACE(ifp);
+    return netdev_alloc_skb(ifp, len);
+}
 /*
  * on tx we force skb->queue_mapping = ring_nr,
  * but on rx it is the driver that sets the value,

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -689,6 +689,18 @@ nm_os_generic_xmit_frame(struct nm_os_gen_arg *a)
 	if (unlikely(skb_headroom(m)))
 		skb_push(m, skb_headroom(m));
 	skb_trim(m, 0);
+	/* Re-reserve the minimum headroom. 
+	 * TODO: just never lose it in the first place ?
+	 */
+	skb_reserve(m, m->dev->needed_headroom);
+	skb_reset_network_header(m);
+	skb_reset_mac_header(m);
+	skb_reset_transport_header(m);
+
+	/* Check there is enough room in the buffer
+	 * skb_copy_to_linear_data does not check. */
+	if (unlikely(skb_availroom(m) < len))
+		BUG();
 
 	/* Copy a netmap buffer into the mbuf.
 	 * TODO Support the slot flags (NS_MOREFRAG, NS_INDIRECT). */


### PR DESCRIPTION
Some drivers, like hv_netvsc, require headroom to do their own
processing. While that is theoretically not required, at least in
Linux 4.2.0 and 4.4.0, the kernel panics if that headroom is not
available.