### PR TITLE
unset the zombie flag on NETDEV_REGISTER (linux) and ifnet_arrival_event (freebsd)

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -81,6 +81,9 @@ linux_netmap_notifier_cb(struct notifier_block *b,
 
 	/* linux calls us while holding rtnl_lock() */
 	switch (val) {
+	case NETDEV_REGISTER:
+		netmap_undo_zombie(ifp);
+		break;
 	case NETDEV_UNREGISTER:
 		netmap_make_zombie(ifp);
 		break;
@@ -949,12 +952,12 @@ linux_netmap_mmap(struct file *f, struct vm_area_struct *vma)
 		pa = netmap_mem_ofstophys(na->nm_mem, 0);
 		if (pa == 0)
 			return -EINVAL;
-		return remap_pfn_range(vma, vma->vm_start, 
+		return remap_pfn_range(vma, vma->vm_start,
 				pa >> PAGE_SHIFT,
 				vma->vm_end - vma->vm_start,
 				vma->vm_page_prot);
 	} else {
-		/* non contiguous memory, we serve 
+		/* non contiguous memory, we serve
 		 * page faults as they come
 		 */
 		vma->vm_private_data = priv;

--- a/sys/dev/netmap/netmap_freebsd.c
+++ b/sys/dev/netmap/netmap_freebsd.c
@@ -116,16 +116,27 @@ nm_os_put_module(void)
 }
 
 static void
+netmap_ifnet_arrival_handler(void *arg __unused, struct ifnet *ifp)
+{
+        netmap_undo_zombie(ifp);
+}
+
+static void
 netmap_ifnet_departure_handler(void *arg __unused, struct ifnet *ifp)
 {
         netmap_make_zombie(ifp);
 }
 
+static eventhandler_tag nm_ifnet_ah_tag;
 static eventhandler_tag nm_ifnet_dh_tag;
 
 int
 nm_os_ifnet_init(void)
 {
+        nm_ifnet_ah_tag =
+                EVENTHANDLER_REGISTER(ifnet_arrival_event,
+                        netmap_ifnet_arrival_handler,
+                        NULL, EVENTHANDLER_PRI_ANY);
         nm_ifnet_dh_tag =
                 EVENTHANDLER_REGISTER(ifnet_departure_event,
                         netmap_ifnet_departure_handler,
@@ -136,6 +147,8 @@ nm_os_ifnet_init(void)
 void
 nm_os_ifnet_fini(void)
 {
+        EVENTHANDLER_DEREGISTER(ifnet_arrival_event,
+                nm_ifnet_ah_tag);
         EVENTHANDLER_DEREGISTER(ifnet_departure_event,
                 nm_ifnet_dh_tag);
 }

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -288,6 +288,7 @@ void nm_os_get_module(void);
 void nm_os_put_module(void);
 
 void netmap_make_zombie(struct ifnet *);
+void netmap_undo_zombie(struct ifnet *);
 
 /* passes a packet up to the host stack.
  * If the packet is sent (or dropped) immediately it returns NULL,


### PR DESCRIPTION
Since commit d8d2569ba01bea1cc5497518125a63370f4551f5, netmap did not work with LXC containers. That is because, to move the device to a new namespace, it is unregistered first. Unregistering a netmap interface leaves it in a zombie state, which renders it unusable.

This patch adds listeners for the NETDEV_REGISTER (linux) and ifnet_arrival_event (freebsd) events and unsets the zombie flag in their handlers if needed.

Please note, I haven't tried the FreeBSD patch. Just tried to mirror what I did for the Linux one.