### PR TITLE
pkt-gen: do not use sizeof(char*) with strncmp

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -627,7 +627,6 @@ static int
 source_hwaddr(const char *ifname, char *buf)
 {
 	struct ifaddrs *ifaphead, *ifap;
-	int l = sizeof(ifap->ifa_name);
 
 	if (getifaddrs(&ifaphead) != 0) {
 		D("getifaddrs %s failed", ifname);
@@ -641,7 +640,7 @@ source_hwaddr(const char *ifname, char *buf)
 
 		if (!sdl || sdl->sdl_family != AF_LINK)
 			continue;
-		if (strncmp(ifap->ifa_name, ifname, l) != 0)
+		if (strncmp(ifap->ifa_name, ifname, IFNAMSIZ) != 0)
 			continue;
 		mac = (uint8_t *)LLADDR(sdl);
 		sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",


### PR DESCRIPTION
ifa_name is a char* on Linux and FreeBSD