### PR TITLE
bump ring pool size

### DIFF
--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -418,7 +418,7 @@ struct netmap_mem_d nm_mem = {	/* Our memory allocator. */
 			.num  = 100,
 		},
 		[NETMAP_RING_POOL] = {
-			.size = 9*PAGE_SIZE,
+			.size = 17*PAGE_SIZE,
 			.num  = 200,
 		},
 		[NETMAP_BUF_POOL] = {


### PR DESCRIPTION
sizeof(struct netmap_slot) is 4+2+2+8 == 16
Assuming PAGE_SIZE is 4096, 17*4096 is enough to allocate
4096 slot entries + sizeof(struct netmap_ring)

This makes it possible to use 4096 TX buffers with the ixgbe driver