### PR TITLE
Updates nmreplay usage display to match functionality.

### DIFF
--- a/apps/nmreplay/nmreplay.c
+++ b/apps/nmreplay/nmreplay.c
@@ -971,7 +971,7 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: nmreplay [-v] [-D delay] [-B {[constant,]bps|ether,bps|real,speedup}] [-L loss]\n"
-	    "\t[-b burst] -i ifa-or-pcap-file -i ifb\n");
+	    "\t[-b burst] -f pcap-file -i ifb\n");
 	exit(1);
 }
 


### PR DESCRIPTION
"-i" is only accepted a single time and the "-f" flag to provide
a pcap file wasn't given at all in the usage output.