### PR TITLE
dkms: fix modules path

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -710,7 +710,7 @@ for d in $(drv print); do
 	drv_distclean=
 	drv_conf="CONFIG_$(basename $d .c | tr a-z- A-Z_)"
 	# possibly override from config.mak
-	eval $(make -nrf read-vars.mak $d@vars E_DRIVERS="$e_drivers")
+	eval $(make -snrf read-vars.mak $d@vars E_DRIVERS="$e_drivers")
 
 	# check that the original driver had been compiled as a module, otherwise
 	# skip this driver

--- a/LINUX/dkms/dkms.conf
+++ b/LINUX/dkms/dkms.conf
@@ -7,45 +7,41 @@ AUTOINSTALL=yes
 # netmap driver
 MAKE[0]=\'make\'
 BUILT_MODULE_NAME[0]=netmap
-BUILT_MODULE_LOCATION[0]=LINUX/
 DEST_MODULE_LOCATION[0]=/kernel/net/netmap/
 
 # forcedeth driver
 BUILT_MODULE_NAME[1]=forcedeth
-BUILT_MODULE_LOCATION[1]=LINUX/
 DEST_MODULE_LOCATION[1]=/kernel/drivers/net/ethernet/nvidia/
 
 # veth driver
 BUILT_MODULE_NAME[2]=veth
-BUILT_MODULE_LOCATION[2]=LINUX/
 DEST_MODULE_LOCATION[2]=/kernel/drivers/net/
 
 # virtio_net driver
 BUILT_MODULE_NAME[3]=virtio_net
-BUILT_MODULE_LOCATION[3]=LINUX/
 DEST_MODULE_LOCATION[3]=/kernel/drivers/net/
 
 # e1000 driver
 BUILT_MODULE_NAME[4]=e1000
-BUILT_MODULE_LOCATION[4]=LINUX/e1000/
+BUILT_MODULE_LOCATION[4]=e1000/
 DEST_MODULE_LOCATION[4]=/kernel/drivers/net/ethernet/intel/e1000/
 
 # e1000e driver
 BUILT_MODULE_NAME[5]=e1000e
-BUILT_MODULE_LOCATION[5]=LINUX/e1000e/
+BUILT_MODULE_LOCATION[5]=e1000e/
 DEST_MODULE_LOCATION[5]=/kernel/drivers/net/ethernet/intel/e1000e/
 
 # igb driver
 BUILT_MODULE_NAME[6]=igb
-BUILT_MODULE_LOCATION[6]=LINUX/igb/
+BUILT_MODULE_LOCATION[6]=igb/
 DEST_MODULE_LOCATION[6]=/kernel/drivers/net/ethernet/intel/igb/
 
 # ixgbe driver
 BUILT_MODULE_NAME[7]=ixgbe
-BUILT_MODULE_LOCATION[7]=LINUX/ixgbe/
+BUILT_MODULE_LOCATION[7]=ixgbe/
 DEST_MODULE_LOCATION[7]=/kernel/drivers/net/ethernet/intel/ixgbe/
 
 # i40e driver
 BUILT_MODULE_NAME[8]=i40e
-BUILT_MODULE_LOCATION[8]=LINUX/i40e/
+BUILT_MODULE_LOCATION[8]=i40e/
 DEST_MODULE_LOCATION[8]=/kernel/drivers/net/ethernet/intel/i40e/


### PR DESCRIPTION
Since eb2e5621c065d6b they are not built from LINUX/ anymore