### PR TITLE
i40e: Set NS_MOREFRAG slot flag if frame is incomplete

### DIFF
--- a/LINUX/i40e_netmap_linux.h
+++ b/LINUX/i40e_netmap_linux.h
@@ -455,6 +455,7 @@ i40e_netmap_rxsync(struct netmap_kring *kring, int flags)
 	if (netmap_no_pendintr || force_update) {
 		int crclen = ix_crcstrip ? 0 : 4;
 		uint16_t slot_flags = kring->nkr_slot_flags;
+		uint16_t curr_slot_flag;
 
 		nic_i = rxr->next_to_clean; // or also k2n(kring->nr_hwtail)
 		nm_i = netmap_idx_n2k(kring, nic_i);
@@ -470,7 +471,13 @@ i40e_netmap_rxsync(struct netmap_kring *kring, int flags)
 			}
 			ring->slot[nm_i].len = ((qword & I40E_RXD_QW1_LENGTH_PBUF_MASK)
 			    >> I40E_RXD_QW1_LENGTH_PBUF_SHIFT) - crclen;
-			ring->slot[nm_i].flags = slot_flags;
+
+			curr_slot_flag = slot_flags;
+			if (unlikely((staterr & (1<<I40E_RX_DESC_STATUS_EOF_SHIFT)) == 0 )) {
+				curr_slot_flag |= NS_MOREFRAG;
+			}
+			ring->slot[nm_i].flags = curr_slot_flag;
+
 			//bus_dmamap_sync(rxr->ptag,
 			//    rxr->buffers[nic_i].pmap, BUS_DMASYNC_POSTREAD);
 			nm_i = nm_next(nm_i, lim);


### PR DESCRIPTION
For Ethernet frames of size larger than 2048 bytes, the ring for this driver always gives buffers of 2048 bytes or smaller chunks, even if the MTU is configured for > 9000 bytes, but it exposes a flag to inform the driver that more fragments are available for this frame.

This patch propagates the "more fragment" flag, from the NIC ring to the Netmap ring.
A similar check is done [in the mainline Linux i40e driver](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/tree/drivers/net/ethernet/intel/i40e/i40e_txrx.c?h=v4.11.7#n1727).

Without this fix, when a 9014 byte frame is captured on the interface, a Netmap reader would receive 5 chunks of sizes : 2048 + 2048 + 2048 + 2048 +  822, without a way to tell if they belong to the same frame or not.

I have tested the change on Intel XL710 10Gbe card.