### PR TITLE
Use htons to initialize packet's ip_len

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -1000,7 +1000,7 @@ initialize_packet(struct targ *targ)
 		ip->ip_hl = sizeof(*ip) >> 2;
 		ip->ip_id = 0;
 		ip->ip_tos = IPTOS_LOWDELAY;
-		ip->ip_len = ntohs(targ->g->pkt_size - sizeof(*eh));
+		ip->ip_len = htons(targ->g->pkt_size - sizeof(*eh));
 		ip->ip_id = 0;
 		ip->ip_off = htons(IP_DF); /* Don't fragment */
 		ip->ip_ttl = IPDEFTTL;


### PR DESCRIPTION
In the expected context the use of htons is more appropriate. htons and
ntohs are actually implemented using the same function on x86, so there
is no actual functional problem.