### PR TITLE
netmap_ioctl: Fix ifnet reference leak on failure.

### DIFF
--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -2312,7 +2312,6 @@ netmap_ioctl(struct netmap_priv_d *priv, u_long cmd, caddr_t data, struct thread
 		NMG_LOCK();
 		do {
 			u_int memflags;
-			struct ifnet *ifp;
 
 			if (priv->np_nifp != NULL) {	/* thread already registered */
 				error = EBUSY;


### PR DESCRIPTION
The redefinition of ifp variable in the registration path was shadowing
a definition of the same variable at the start of netmap_ioctl function
and in case of netmap_do_regif failure the error path was trying to
unref the outer variable which contains NULL, while the ifnet object was
pointed by the inner ifp variable and as it went out of scope the ifnet
object will have one extra reference.