### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+sudo: false
+language: c
+cache:
+  directories:
+    - $HOME/Linux
+env:
+  - KERNEL_VERSION=3.2   ARCH=i386
+  - KERNEL_VERSION=3.4   ARCH=i386
+  - KERNEL_VERSION=3.10  ARCH=i386
+  - KERNEL_VERSION=3.16  ARCH=i386
+  - KERNEL_VERSION=4.1   ARCH=i386
+  - KERNEL_VERSION=4.4   ARCH=i386
+  - KERNEL_VERSION=4.9   ARCH=i386
+  - KERNEL_VERSION=linus ARCH=i386
+  - KERNEL_VERSION=3.2   ARCH=x86_64
+  - KERNEL_VERSION=3.4   ARCH=x86_64
+  - KERNEL_VERSION=3.10  ARCH=x86_64
+  - KERNEL_VERSION=3.16  ARCH=x86_64
+  - KERNEL_VERSION=4.1   ARCH=x86_64
+  - KERNEL_VERSION=4.4   ARCH=x86_64
+  - KERNEL_VERSION=4.9   ARCH=x86_64
+  - KERNEL_VERSION=linus ARCH=x86_64
+matrix:
+  allow_failures:
+    - env: KERNEL_VERSION=linus ARCH=i386
+    - env: KERNEL_VERSION=linus ARCH=x86_64
+script:
+  - "./ci/build-linux $KERNEL_VERSION $ARCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: c
 cache:
   directories:
     - $HOME/Linux
+    - $HOME/Drivers
 env:
   - KERNEL_VERSION=3.2   ARCH=i386
   - KERNEL_VERSION=3.4   ARCH=i386
@@ -25,5 +26,7 @@ matrix:
   allow_failures:
     - env: KERNEL_VERSION=linus ARCH=i386
     - env: KERNEL_VERSION=linus ARCH=x86_64
+install:
+  - "rm -Rf LINUX/ext-drivers && mkdir -p $HOME/Drivers && ln -sv $HOME/Drivers LINUX/ext-drivers"
 script:
   - "./ci/build-linux $KERNEL_VERSION $ARCH"

--- a/ci/build-linux
+++ b/ci/build-linux
@@ -1,0 +1,53 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+readonly KERNEL_VERSION=${1:?}
+readonly ARCH=${2:?}
+readonly GCC_MAJOR_VERSION=$(echo '#include <stdio.h>
+void main() { printf("%u\n", __GNUC__); }' | gcc -x c - -o /tmp/getgccversion  && /tmp/getgccversion)
+readonly PROC_COUNT=$(grep -c '^processor' /proc/cpuinfo)
+
+
+if [ ! -d ~/Linux/$KERNEL_VERSION ]
+then
+  # clone
+  if [ "$KERNEL_VERSION" = "linus" ]
+  then
+    git clone 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git' ~/Linux/$KERNEL_VERSION
+  else
+    git clone 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git' ~/Linux/$KERNEL_VERSION
+    pushd ~/Linux/$KERNEL_VERSION
+    git checkout linux-${KERNEL_VERSION}.y
+    popd
+  fi
+else
+  # update
+  pushd ~/Linux/$KERNEL_VERSION
+  git pull
+  popd
+fi
+
+# configure kernel
+pushd ~/Linux/$KERNEL_VERSION
+compiler_file=compiler-gcc${GCC_MAJOR_VERSION}.h
+if [ ! -f include/linux/${compiler_file} -a ! -h include/linux/${compiler_file} ]
+then
+  # fix compilation of old kernels with recent GCC
+  pushd include/linux
+  if [ -f compiler-gcc5.h -a $GCC_MAJOR_VERSION -gt 5 ]
+  then
+    ln -sv compiler-gcc5.h ${compiler_file}
+  else
+    ln -sv compiler-gcc4.h ${compiler_file}
+  fi
+  popd
+fi
+make mrproper
+make -j $PROC_COUNT ARCH=${ARCH} defconfig
+make -j $PROC_COUNT ARCH=${ARCH} modules_prepare
+popd
+
+# build
+./configure --kernel-dir=$HOME/Linux/$KERNEL_VERSION
+make -j $PROC_COUNT


### PR DESCRIPTION
This adds integration with [Travis CI](https://travis-ci.org/) continuous integration service (free for open source projects).

For now the job (triggered automatically for each commit), will compile Netmap on Linux with all drivers, with several long term kernel versions and i386/x86_64 CPU architectures.
Basically it checks Netmap and its drivers compiles fines on Linux with a large range of kernel configurations, which can be very tedious to check manually. 

As an immediate benefit, it shows that Netmap is broken with the latest kernel version (Linus branch) : https://travis-ci.org/desbma/netmap/jobs/253780111#L957.

In the future we could expand the scope of the job to run automated tests, for example by firing up Qemu with a simulated e1000 NIC and exchanging some packets.

If you agree to merge this, you'll need to create a Travis account and link it to the Github account. 
As an additional benefit the Travis job automatically runs when a pull request is proposed, which would then check if anything broke Linux compilation.