### PR TITLE
Updated the README about e1000 patch issue seen in 3.10 kernel version

### DIFF
--- a/LINUX/README
+++ b/LINUX/README
@@ -267,6 +267,17 @@ COMMON PROBLEMS
   In emulated netmap mode (i.e. with unpatched drivers) VLAN tags are never
   visible by the netmap application.
 
+* if you are using e1000 with netmap, you verify the result of the patch from
+  final-patches/vanilla--e1000--20620--31200 that was applied on
+  e1000/e1000_main.c. It was observed that when using older kernel version
+  netmap hook that needs to be applied on e1000_clean_rx_irq is actually 
+  applied on e1000_clean_jumbo_rx_irq. As a result it will end up in packets
+  going directly from NIC Rx Rings to Host stack.
+
+     # Do manual changes in e1000/e1000_main.c
+
+  If patch is wrongly applied on e1000_clean_jumbo_rx_irq, then apply the
+  required netmap hook in e1000_clean_rx_irq from e1000_clean_jumbo_rx_irq.
 
 REVISION HISTORY
 -----------------

--- a/LINUX/README
+++ b/LINUX/README
@@ -267,17 +267,15 @@ COMMON PROBLEMS
   In emulated netmap mode (i.e. with unpatched drivers) VLAN tags are never
   visible by the netmap application.
 
-* if you are using e1000 with netmap, you verify the result of the patch from
-  final-patches/vanilla--e1000--20620--31200 that was applied on
-  e1000/e1000_main.c. It was observed that when using older kernel version
+* if you are using e1000 with netmap, you should verify the result of the patch
+  from final-patches/vanilla--e1000--20620--31200 that was applied on
+  e1000/e1000_main.c. It was observed that when using non-vanilla kernel version
   netmap hook that needs to be applied on e1000_clean_rx_irq is actually 
   applied on e1000_clean_jumbo_rx_irq. As a result it will end up in packets
   going directly from NIC Rx Rings to Host stack.
 
-     # Do manual changes in e1000/e1000_main.c
-
-  If patch is wrongly applied on e1000_clean_jumbo_rx_irq, then apply the
-  required netmap hook in e1000_clean_rx_irq from e1000_clean_jumbo_rx_irq.
+     # You should fix this issue by manually patching e1000/e1000_main.c to add
+  the correct netmap hook in e1000_clean_rx_irq
 
 REVISION HISTORY
 -----------------

--- a/LINUX/README
+++ b/LINUX/README
@@ -273,8 +273,8 @@ COMMON PROBLEMS
   netmap hook that needs to be applied on e1000_clean_rx_irq is actually 
   applied on e1000_clean_jumbo_rx_irq. As a result it will end up in packets
   going directly from NIC Rx Rings to Host stack.
-
-     # You should fix this issue by manually patching e1000/e1000_main.c to add
+      
+      You should fix this issue by manually patching e1000/e1000_main.c to add
   the correct netmap hook in e1000_clean_rx_irq
 
 REVISION HISTORY


### PR DESCRIPTION
Problem statement
==============
patch final-patches/vanilla--e1000--20620--31200 is getting wrongly applied with 3.10 kernel version that is used for CentOS 7.3

Overview of changes
================
Updated the LINUX/README,  "COMMON PROBLEMS" section to alert the user of e1000 with netmap about the patch.
