### PR TITLE
Check if carrier present instead of running.

### DIFF
--- a/LINUX/i40e_netmap_linux.h
+++ b/LINUX/i40e_netmap_linux.h
@@ -283,7 +283,7 @@ i40e_netmap_txsync(struct netmap_kring *kring, int flags)
 	struct i40e_vsi *vsi = np->vsi;
 	struct i40e_ring *txr;
 
-	if (!netif_running(ifp))
+	if (!netif_carrier_ok(ifp))
 		return 0;
 
 	txr = NM_I40E_TX_RING(vsi, kring->ring_id);


### PR DESCRIPTION
Replace the check whether interface is running with a check whether
there is actual carrier, otherwise packets will be reported as sent
although there is no actual link on the interface.

Tested by sending packets with:
```
pkt-gen -i ethX -f tx -n 0 -l 1500
```

Pkt-gen shows that it is sending packets even after the cable was
physically unplugged from the interface.

The check in ixgbe is the same in txsync handler.