### PR TITLE
Fixed lut_entry has no paddr member issue

### DIFF
--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -2197,7 +2197,7 @@ netmap_mem_pt_guest_finalize(struct netmap_mem_d *nmd)
 
 	for (i = 0; i < nbuffers; i++) {
 		ptnmd->buf_lut.lut[i].vaddr = vaddr;
-		ptnmd->buf_lut.lut[i].paddr = paddr;
+		ptnmd->buf_lut.plut[i].paddr = paddr;
 		vaddr += bufsize;
 		paddr += bufsize;
 	}


### PR DESCRIPTION
The error: 'struct lut_entry' has no member named 'paddr'