### PR TITLE
Reg range support

### DIFF
--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -1808,6 +1808,21 @@ netmap_interp_ringid(struct netmap_priv_d *priv, uint16_t ringid, uint32_t flags
 			ND("ONE_NIC: %s %d %d", nm_txrx2str(t),
 				priv->np_qfirst[t], priv->np_qlast[t]);
 			break;
+		case NR_REG_RANGE_NIC:
+			if (i >= nma_get_nrings(na, t)) {
+				D("invalid ring id %d", i);
+				return EINVAL;
+			}
+			j = (flags & NR_RANGE_END_MASK) >> NR_RANGE_END_SHIFT;
+			if (j >= nma_get_nrings(na, t)) {
+				D("invalid range end %d", j);
+				return EINVAL;
+			}
+			priv->np_qfirst[t] = i;
+			priv->np_qlast[t] = j + 1;
+			ND("RANGE_NIC: %s %d %d", nm_txrx2str(t),
+				priv->np_qfirst[t], priv->np_qlast[t]);
+			break;
 		default:
 			D("invalid regif type %d", reg);
 			return EINVAL;

--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -544,6 +544,7 @@ enum {	NR_REG_DEFAULT	= 0,	/* backward compat, should not be used. */
 	NR_REG_ONE_NIC	= 4,
 	NR_REG_PIPE_MASTER = 5,
 	NR_REG_PIPE_SLAVE = 6,
+	NR_REG_RANGE_NIC = 7,
 };
 /* monitor uses the NR_REG to select the rings to monitor */
 #define NR_MONITOR_TX	0x100
@@ -562,6 +563,9 @@ enum {	NR_REG_DEFAULT	= 0,	/* backward compat, should not be used. */
  * to use those headers. If the flag is set, the application can use the
  * NETMAP_VNET_HDR_GET command to figure out the header length. */
 #define NR_ACCEPT_VNET_HDR	0x8000
+
+#define NR_RANGE_END_MASK		0xfff00000u /* values for range end parameter */
+#define NR_RANGE_END_SHIFT		__builtin_ctz(NR_RANGE_END_MASK) /* how much to shr to get the range end number */
 
 #define	NM_BDG_NAME		"vale"	/* prefix for bridge port name */
 


### PR DESCRIPTION
While following issue #355 I saw this [comment](https://github.com/luigirizzo/netmap/issues/355#issuecomment-337286314) from @giuseppelettieri which matched an idea I was contemplating for a while - to be able to register a range of rings with NetMap. Such change will achieve:
- easy monitoring of multiple RX queues, instead of creating a fd per ring and managing all of them.
- easy implementation of spreading of rings between threads in _pkt-gen_ - you just need to register a range instead of just one ring when you call `nm_open` and the threading code should just work from there on.

Due to the clever design of NetMap the needed patch to support this feature is surprisingly small and this PR is an attempt to achieve this functionality. It contains the following changes:

* `netmap_interp_ringid` parses a new registration option `NR_REG_RANGE_NIC` which will update accordingly `np_qfirst` and `np_qlast` fields.
* The range start is passed as it is now using `nr_ringid` and the end of the range is passed through the 12 MSBs in `nr_flags`
* `nm_open` can parse an interface in the following format `ethX-2-5` which will register rings [2, 5] to the descriptor.

I played a while with _pkt-gen_ sending and receiving traffic from different ranges of queues, so may be a natural step is the modification mentioned in #355. But first as I'm not too familiar with the code of NetMap I would like to inquire NetMap's devs whether:
- A range registration is something which will make NetMap easier to use and will be accepted?
- There's a better way to pass the end of the range to the kernel?
- Are there any obvious issues which could arise with the current code?