### PR TITLE
mem: fix non-const casting of nr_buf_size

### DIFF
--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -1793,7 +1793,7 @@ netmap_mem2_rings_create(struct netmap_adapter *na)
 			ring->head = kring->rhead;
 			ring->cur = kring->rcur;
 			ring->tail = kring->rtail;
-			*(uint16_t *)(uintptr_t)&ring->nr_buf_size =
+			*(uint32_t *)(uintptr_t)&ring->nr_buf_size =
 				netmap_mem_bufsize(na->nm_mem);
 			ND("%s h %d c %d t %d", kring->name,
 				ring->head, ring->cur, ring->tail);


### PR DESCRIPTION
One some platforms this previously resulted in
nr_buf_size being initialised to random values
as only 16-bits of the 32 bit value was set.
The symtoms were that buffer offsets were
incorrectly calculated and invalid memory
accesses occurred.