### PR TITLE
Add (G)ARP sender to fix switch broadcast storms

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -2366,7 +2366,6 @@ quit:
 	return (NULL);
 }
 
-#define norm(a,b,c)	norm(a,b)
 
 static void
 tx_output(struct my_ctrs *cur, double delta, const char *msg)


### PR DESCRIPTION
On many switches it's basically impossible to use pkt-gen without sending regular ARPs to maintain association with the switch port. When the PHY resets into netmap mode, the association is usually lost, causing traffic to be broadcast to all ports. This breaks the receiver and destroys network performance.

Also added link state auto wait option when you specify -w0.

I have tested on Linux boxes only, so there is a chance of broken builds for other platforms. Could someone check FreeBSD etc?