### PR TITLE
Changed NM_BRIDGES to 256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ read-vars.mak
 LINUX/scripts/conf
 config.mak
 *.rej
+G*A*

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -1443,7 +1443,7 @@ struct netmap_bdg_ops {
 u_int netmap_bdg_learning(struct nm_bdg_fwd *ft, uint8_t *dst_ring,
 		struct netmap_vp_adapter *);
 
-#define	NM_BRIDGES		8	/* number of bridges */
+#define	NM_BRIDGES		256	/* number of bridges */
 #define	NM_BDG_MAXPORTS		254	/* up to 254 */
 #define	NM_BDG_BROADCAST	NM_BDG_MAXPORTS
 #define	NM_BDG_NOPORT		(NM_BDG_MAXPORTS+1)

--- a/sys/dev/netmap/netmap_vale.c
+++ b/sys/dev/netmap/netmap_vale.c
@@ -711,7 +711,6 @@ netmap_get_bdg_na(struct nmreq *nmr, struct netmap_adapter **na,
 	struct netmap_vp_adapter *vpna, *hostna = NULL;
 	struct nm_bridge *b;
 	int i, j, cand = -1, cand2 = -1;
-	int needed;
 
 	*na = NULL;     /* default return value */
 
@@ -752,8 +751,7 @@ netmap_get_bdg_na(struct nmreq *nmr, struct netmap_adapter **na,
 	if (!create)
 		return ENXIO;
 	/* yes we should, see if we have space to attach entries */
-	needed = 2; /* in some cases we only need 1 */
-	if (b->bdg_active_ports + needed >= NM_BDG_MAXPORTS) {
+	if (b->bdg_active_ports >= NM_BDG_MAXPORTS) {
 		D("bridge full %d, cannot create new port", b->bdg_active_ports);
 		return ENOMEM;
 	}


### PR DESCRIPTION
Added GTAGS to .gitignore and fixed vale port max not 254 issue #398 

To NM_BRIDGES default to 256 because the original default value `8` 
is too small for even test, and `256` is OK for hypervisor usage.