### PR TITLE
_BSD_SOURCE is already defined in /usr/include/features.h (CentOS 7.4)

### DIFF
--- a/apps/dedup/dedup.h
+++ b/apps/dedup/dedup.h
@@ -1,7 +1,9 @@
 #ifndef DEDUP_H_
 #define DEDUP_H_
 
+#ifndef _BSD_SOURCE
 #define _BSD_SOURCE
+#endif
 #include <time.h>
 #include <limits.h>
 


### PR DESCRIPTION
My build on CentOS 7.4 failed with the error
```
make[1]: Entering directory `/build/netmap-sl74/build-apps/dedup'
cc -O2 -pipe -g -Werror -Wall -Wunused-function -I /build/netmap-sl74/LINUX/../sys -I /build/netmap-sl74/LINUX/../apps/include -Wextra   -c -o dedup.o /build/netmap-sl74/LINUX/../apps/dedup/dedup.c
In file included from /build/netmap-sl74/LINUX/../apps/dedup/dedup.c:6:0:
/build/netmap-sl74/LINUX/../apps/dedup/dedup.h:4:0: error: "_BSD_SOURCE" redefined [-Werror]
 #define _BSD_SOURCE
 ^
In file included from /usr/include/stdio.h:27:0,
                 from /build/netmap-sl74/LINUX/../apps/dedup/dedup.c:1:
/usr/include/features.h:188:0: note: this is the location of the previous definition
 # define _BSD_SOURCE 1
 ^
cc1: all warnings being treated as errors
make[1]: *** [dedup.o] Error 1
make[1]: Leaving directory `/build/netmap-sl74/build-apps/dedup'
make: *** [build-app-dedup] Error 2
```

I have no idea, if my patch lets me compile the code now. Please advise, if you want to do it in another way.