### PR TITLE
Add support for Mellanox ConnectX-4 / ConnectX-5 cards (v3.3 mlx5 driver)

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -110,7 +110,7 @@ subsys enable generic
 
 # available drivers
 driver_avail="r8169.c virtio_net.c forcedeth.c veth.c \
-	e1000 e1000e igb ixgbe ixgbevf i40e vmxnet3"
+	e1000 e1000e igb ixgbe ixgbevf i40e vmxnet3 mlx5"
 # enabled drivers (bitfield)
 driver=
 drv()

--- a/LINUX/final-patches/mellanox--mlx5--3.3
+++ b/LINUX/final-patches/mellanox--mlx5--3.3
@@ -1,0 +1,379 @@
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile
+index b8ce0b5..574d21a 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile
+@@ -1,12 +1,13 @@
+ ccflags-y += $(MLNX_CFLAGS)
+ 
+-obj-$(CONFIG_MLX5_CORE)		+= mlx5_core.o
++obj-$(CONFIG_MLX5_CORE)		+= mlx5_core$(NETMAP_DRIVER_SUFFIX).o
+ 
+-mlx5_core-y :=	main.o cmd.o debugfs.o fw.o eq.o uar.o pagealloc.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-y :=	main.o cmd.o debugfs.o fw.o eq.o uar.o pagealloc.o \
+ 		health.o mcg.o cq.o srq.o alloc.o qp.o port.o mr.o pd.o   \
+ 		mad.o wq.o vport.o transobj.o en_main.o \
+ 		en_ethtool.o en_tx.o en_rx.o en_txrx.o \
+ 		sriov.o params.o en_debugfs.o en_selftest.o en_sysfs.o en_ecn.o \
+ 		en_dcb_nl.o fs_cmd.o fs_core.o fs_debugfs.o en_fs.o \
+ 		eswitch.o vxlan.o en_clock.o en_sniffer.o rl.o
+-mlx5_core-$(CONFIG_RFS_ACCEL) +=  en_arfs.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_RFS_ACCEL) +=  en_arfs.o
++
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_ethtool.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_ethtool.c
+index 847d804..342c754 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_ethtool.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_ethtool.c
+@@ -32,6 +32,12 @@
+ 
+ #include "en.h"
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++#define NETMAP_GET_RQ_TYPE(mdev)  RQ_TYPE_NONE  /* ensure RQ_TYPE_STRIDE not used with netmap */
++#else
++#define NETMAP_GET_RQ_TYPE(mdev)  MLX5_CAP_GEN(mdev, striding_rq)
++#endif
++
+ static const char mlx5e_test_names[][ETH_GSTRING_LEN] = {
+ 	"Speed Test",
+ 	"Link Test",
+@@ -468,8 +474,7 @@ static void mlx5e_get_ringparam(struct net_device *dev,
+ 				struct ethtool_ringparam *param)
+ {
+ 	struct mlx5e_priv *priv = netdev_priv(dev);
+-	int rq_wq_type = MLX5_CAP_GEN(priv->mdev, striding_rq);
+-
++	int rq_wq_type = NETMAP_GET_RQ_TYPE(priv->mdev);  /* Add netmap support */
+ 	param->rx_max_pending =
+ 		mlx5e_rx_wqes_to_packets(rq_wq_type,
+ 					   1 << mlx5_max_log_rq_size(rq_wq_type));
+@@ -485,7 +490,7 @@ static int mlx5e_set_ringparam(struct net_device *dev,
+ {
+ 	struct mlx5e_priv *priv = netdev_priv(dev);
+ 	struct mlx5e_params new_params;
+-	int rq_wq_type = MLX5_CAP_GEN(priv->mdev, striding_rq);
++	int rq_wq_type = NETMAP_GET_RQ_TYPE(priv->mdev);  /* Add netmap support */
+ 	u16 min_rx_wqes;
+ 	u8 log_rq_size;
+ 	u8 log_sq_size;
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+index 70fd71a..48644dc 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+@@ -61,6 +61,19 @@ struct mlx5e_channel_param {
+ 	struct mlx5e_cq_param      tx_cq;
+ };
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++/*
++ * mlx5_netmap_linux.h contains functions for netmap support
++ * that extend the standard driver.
++ */
++#define NETMAP_MLX5_MAIN
++#include "mlx5_netmap_linux.h"
++
++#define NETMAP_GET_RQ_TYPE(mdev)  RQ_TYPE_NONE  /* ensure RQ_TYPE_STRIDE not used with netmap */
++#else
++#define NETMAP_GET_RQ_TYPE(mdev)  MLX5_CAP_GEN(mdev, striding_rq)
++#endif
++
+ static void mlx5e_update_carrier(struct mlx5e_priv *priv)
+ {
+ 	struct mlx5_core_dev *mdev = priv->mdev;
+@@ -351,8 +364,7 @@ static int mlx5e_create_rq(struct mlx5e_channel *c,
+ 
+ 	param->wq.db_numa_node = cpu_to_node(c->cpu);
+ 
+-	rq->rq_type =  MLX5_CAP_GEN(mdev, striding_rq);
+-
++	rq->rq_type =  NETMAP_GET_RQ_TYPE(mdev);  /* Add netmap support */
+ 	err = mlx5_wq_ll_create(mdev, &param->wq, rqc_wq, &rq->wq,
+ 				&rq->wq_ctrl);
+ 	if (err)
+@@ -415,6 +427,10 @@ static int mlx5e_create_rq(struct mlx5e_channel *c,
+ 	rq->channel = c;
+ 	rq->ix      = c->ix;
+ 
++#ifdef DEV_NETMAP
++	mlx5e_netmap_configure_rx_ring(rq, rq->ix);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_rq_wq_destroy:
+@@ -551,6 +567,11 @@ static int mlx5e_wait_for_min_rx_wqes(struct mlx5e_rq *rq)
+ 	struct mlx5_wq_ll *wq = &rq->wq;
+ 	int i;
+ 
++#ifdef DEV_NETMAP
++	if (nm_netmap_on(NA(c->netdev)))
++		return 0; /* no need to wait when netmap has built wqes */
++#endif
++
+ 	for (i = 0; i < MLX5_EN_MAX_ITER; i++) {
+ 		if (wq->cur_sz >= priv->params.min_rx_wqes)
+ 			return 0;
+@@ -636,7 +657,12 @@ static int mlx5e_open_rq(struct mlx5e_channel *c,
+ 	if (err)
+ 		goto err_disable_rq;
+ 
+-	set_bit(MLX5E_RQ_STATE_POST_WQES_ENABLE, &rq->state);
++#ifdef DEV_NETMAP
++	if (!nm_netmap_on(NA(c->netdev)))
++#endif
++	{
++		set_bit(MLX5E_RQ_STATE_POST_WQES_ENABLE, &rq->state);
++	}
+ 	mlx5e_send_nop(&c->sq[0], true); /* trigger mlx5e_post_rx_wqes() */
+ 
+ 	return 0;
+@@ -660,9 +686,15 @@ static void mlx5e_close_rq(struct mlx5e_rq *rq)
+ 
+ 	mlx5e_modify_rq_state(rq, MLX5_RQC_STATE_RDY, MLX5_RQC_STATE_ERR);
+ 	if (!priv->internal_error) {
+-		for (i = 0; i < MLX5_EN_MAX_ITER && !mlx5_wq_ll_is_empty(&rq->wq); i++)
++		for (i = 0; i < MLX5_EN_MAX_ITER && !mlx5_wq_ll_is_empty(&rq->wq); i++) {
+ 			msleep(MLX5_EN_MSLEEP_QUANT);
+ 
++#ifdef DEV_NETMAP
++			if (nm_netmap_on(NA(c->netdev)))
++				mlx5e_netmap_rx_flush(rq); /* handle the CQEs */
++#endif
++		}
++
+ 		if (i == MLX5_EN_MAX_ITER)
+ 			pr_warn("%s: aborted\n", __func__);
+ 	}
+@@ -751,6 +783,11 @@ static int mlx5e_create_sq(struct mlx5e_channel *c,
+ 	sq->bf_budget = MLX5E_SQ_BF_BUDGET;
+ 	sq->edge      = (sq->wq.sz_m1 + 1) - MLX5_SEND_WQE_MAX_WQEBBS;
+ 
++#ifdef DEV_NETMAP
++	if (mlx5e_netmap_configure_tx_ring(priv, txq_ix))
++		return 0;
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_sq_wq_destroy:
+@@ -913,9 +950,14 @@ static void mlx5e_close_sq(struct mlx5e_priv *priv, struct mlx5e_sq *sq)
+ 	napi_synchronize(&sq->channel->napi); /* prevent netif_tx_wake_queue */
+ 	netif_tx_disable_queue(sq->txq);
+ 
+-	/* ensure hw is notified of all pending wqes */
+-	if (mlx5e_sq_has_room_for(sq, 1))
+-		mlx5e_send_nop(sq, true);
++#ifdef DEV_NETMAP
++	if (!nm_netmap_on(NA(priv->netdev)))
++#endif
++	{
++		/* ensure hw is notified of all pending wqes */
++		if (mlx5e_sq_has_room_for(sq, 1))
++			mlx5e_send_nop(sq, true);
++	}
+ 
+ 	err = mlx5e_modify_sq(sq, MLX5_SQC_STATE_RDY, MLX5_SQC_STATE_ERR, false, 0);
+ 	if (!priv->internal_error && !err) {
+@@ -924,6 +966,11 @@ static void mlx5e_close_sq(struct mlx5e_priv *priv, struct mlx5e_sq *sq)
+ 			    test_bit(MLX5E_SQ_TX_TIMEOUT, &sq->state))
+ 				break;
+ 			msleep(MLX5_EN_MSLEEP_QUANT);
++
++#ifdef DEV_NETMAP
++			if (nm_netmap_on(NA(priv->netdev)))
++				mlx5e_netmap_tx_flush(sq); /* handle any CQEs */
++#endif
+ 		}
+ 
+ 		if (i == MLX5_EN_MAX_ITER)
+@@ -1400,7 +1447,7 @@ static void mlx5e_build_rq_param(struct mlx5e_priv *priv,
+ 	MLX5_SET(wq, wq, pd,               priv->pdn);
+ 	MLX5_SET(rqc,  rqc, counter_set_id, priv->counter_set_id);
+ 
+-	if (MLX5_CAP_GEN(priv->mdev, striding_rq) == RQ_TYPE_STRIDE) {
++	if (NETMAP_GET_RQ_TYPE(priv->mdev) == RQ_TYPE_STRIDE) {
+ 		MLX5_SET(wq, wq, wq_type, MLX5_WQ_TYPE_STRQ);
+ 		MLX5_SET(wq, wq, log_wqe_num_of_strides,
+ 			 MLX5E_PARAMS_DEFAULT_LOG_WQE_NUM_STRIDES);
+@@ -1451,7 +1498,7 @@ static void mlx5e_build_rx_cq_param(struct mlx5e_priv *priv,
+ 		MLX5_SET(cqc, cqc, cqe_comp_en, 1);
+ 	}
+ 
+-	if (MLX5_CAP_GEN(priv->mdev, striding_rq) == RQ_TYPE_STRIDE) {
++	if (NETMAP_GET_RQ_TYPE(priv->mdev) == RQ_TYPE_STRIDE) {
+ 		MLX5_SET(cqc, cqc, log_cq_size, priv->params.log_rq_size +
+ 			 ilog2(MLX5E_PARAMS_HW_NUM_STRIDES_BASIC_VAL) +  MLX5E_PARAMS_DEFAULT_LOG_WQE_NUM_STRIDES);
+ 		/* Currently disable compressed with striding */
+@@ -2185,6 +2232,10 @@ int mlx5e_open_locked(struct net_device *netdev)
+ #endif
+ 	mlx5e_set_rx_mode_core(priv);
+ 
++#ifdef DEV_NETMAP
++	netmap_enable_all_rings(netdev); /* NOP if netmap not in use */
++#endif
++
+ 	queue_delayed_work(priv->wq, &priv->update_stats_work, 0);
+ 	queue_delayed_work(priv->wq, &priv->service_task, 0);
+ 
+@@ -2246,6 +2297,10 @@ int mlx5e_close_locked(struct net_device *netdev)
+ 	}
+ 	clear_bit(MLX5E_STATE_OPENED, &priv->state);
+ 
++#ifdef DEV_NETMAP
++	netmap_disable_all_rings(netdev);
++#endif
++
+ 	mlx5e_set_rx_mode_core(priv);
+ #if defined(HAVE_VXLAN_ENABLED) && defined(HAVE_VXLAN_DYNAMIC_PORT)
+ 	mlx5e_vxlan_cleanup(priv);
+@@ -3077,16 +3132,16 @@ static void mlx5e_build_netdev_priv(struct mlx5_core_dev *mdev,
+ 	netdev_rss_key_fill(priv->params.toeplitz_hash_key,
+ 			    sizeof(priv->params.toeplitz_hash_key));
+ 
+-	if (MLX5_CAP_GEN(mdev, striding_rq)) {
++	if (NETMAP_GET_RQ_TYPE(mdev)) {  /* Add netmap support */
+ 		/* TODO ethtoo for these params */
+ 		priv->params.log_rq_size = MLX5E_PARAMS_DEFAULT_LOG_STRIDING_RQ_SIZE;
+ 	}
+ 	priv->params.min_rx_wqes =
+-		mlx5_min_rx_wqes(MLX5_CAP_GEN(mdev, striding_rq),
++		mlx5_min_rx_wqes(NETMAP_GET_RQ_TYPE(mdev),
+ 				 BIT(priv->params.log_rq_size));
+ 	/* TODO: add user ability to configure lro wqe size */
+ 	/* Enable LRO by default in case of strided RQ is supported */
+-	if (MLX5_CAP_GEN(mdev, striding_rq) && MLX5_CAP_ETH(mdev, lro_cap)) {
++	if (NETMAP_GET_RQ_TYPE(mdev) && MLX5_CAP_ETH(mdev, lro_cap)) {
+ 		priv->params.lro_en = true;
+ #ifdef CONFIG_COMPAT_LRO_ENABLED_IPOIB
+ 		priv->pflags |= MLX5E_PRIV_FLAG_HWLRO;
+@@ -3353,6 +3408,10 @@ static void *mlx5e_create_netdev(struct mlx5_core_dev *mdev)
+ 	if (err)
+ 		goto err_unregister_netdev;
+ 
++#ifdef DEV_NETMAP
++	mlx5e_netmap_attach(priv);
++#endif /* DEV_NETMAP */
++
+ 	return priv;
+ 
+ err_unregister_netdev:
+@@ -3387,6 +3446,10 @@ static void mlx5e_destroy_netdev(struct mlx5_core_dev *mdev, void *vpriv)
+ 	struct mlx5e_priv *priv = vpriv;
+ 	struct net_device *netdev = priv->netdev;
+ 
++#ifdef DEV_NETMAP
++	netmap_detach(netdev);
++#endif /* DEV_NETMAP */
++
+ 	mlx5e_sysfs_remove(netdev);
+ 
+ 	if (test_bit(MLX5_INTERFACE_STATE_SHUTDOWN, &mdev->intf_state))
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
+index f8bc512..d09a7e2 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
+@@ -40,19 +40,23 @@
+ 	(priv->tstamp.hwtstamp_config.rx_filter ==	\
+ 		     HWTSTAMP_FILTER_ALL)
+ 
+-static inline void mlx5e_read_cqe_slot(struct mlx5e_cq *cq, u32 cc, void *data)
++/* Removed "static" from next four functions so they can
++ * be used from mlx5_netmap_linux.c for handling compressed
++ * CQEs in mlx5e_netmap_rxsync()
++ */
++inline void mlx5e_read_cqe_slot(struct mlx5e_cq *cq, u32 cc, void *data)
+ {
+ 	memcpy(data, mlx5_cqwq_get_wqe(&cq->wq, (cc & cq->wq.sz_m1)),
+ 	       sizeof(struct mlx5_cqe64));
+ }
+ 
+-static inline void mlx5e_write_cqe_slot(struct mlx5e_cq *cq, u32 cc, void *data)
++inline void mlx5e_write_cqe_slot(struct mlx5e_cq *cq, u32 cc, void *data)
+ {
+ 	memcpy(mlx5_cqwq_get_wqe(&cq->wq, cc & cq->wq.sz_m1),
+ 	       data, sizeof(struct mlx5_cqe64));
+ }
+ 
+-static inline void mlx5e_decompress_cqe(struct mlx5e_cq *cq,
++inline void mlx5e_decompress_cqe(struct mlx5e_cq *cq,
+ 					struct mlx5_cqe64 *title,
+ 					struct mlx5_mini_cqe8 *mini,
+ 					u16 wqe_counter, int i)
+@@ -65,7 +69,7 @@ static inline void mlx5e_decompress_cqe(struct mlx5e_cq *cq,
+ }
+ 
+ #define MLX5E_MINI_ARRAY_SZ 8
+-static void mlx5e_decompress_cqes(struct mlx5e_cq *cq)
++void mlx5e_decompress_cqes(struct mlx5e_cq *cq)
+ {
+ 	struct mlx5_mini_cqe8 mini_array[8];
+ 	struct mlx5_cqe64 title;
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_txrx.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_txrx.c
+index 721fabc..2526e79 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_txrx.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_txrx.c
+@@ -34,6 +34,14 @@
+ #include <linux/irq.h>
+ #include <linux/prefetch.h>
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++/*
++ * mlx5_netmap_linux.h contains functions for netmap support
++ * that extend the standard driver.
++ */
++#include "mlx5_netmap_linux.h"
++#endif
++
+ void mlx5e_prefetch_cqe(struct mlx5e_cq *cq)
+ {
+ 	struct mlx5_cqwq *wq = &cq->wq;
+@@ -92,6 +100,50 @@ int mlx5e_napi_poll(struct napi_struct *napi, int budget)
+ 
+ 	clear_bit(MLX5E_CHANNEL_NAPI_SCHED, &c->flags);
+ 
++#ifdef DEV_NETMAP
++	if (nm_netmap_on(NA(c->netdev))) {
++		/*
++		 * In netmap mode, all the work is done in the context
++		 * of the client thread. Interrupt handlers only wake up
++		 * clients, which may be sleeping on individual rings
++		 * or on a global resource for all rings.
++		 */
++		struct mlx5e_rq *rq = &c->rq;
++		int dummy;
++
++		/* Wake netmap rx client. This results in a call to
++		 * mlx5e_netmap_rxsync() which will check for any
++		 * received packets and process them
++		 */
++		netmap_rx_irq(rq->netdev, rq->ix, &dummy);
++
++		for (i = 0; i < c->num_tc; i++) {
++
++			struct mlx5e_cq *scq = &c->sq[i].cq;
++
++			/* Wake netmap tx client. This results in a call to
++			 * mlx5e_netmap_txsync()  which will check if a batch
++			 * of packets has finished sending and recycle the
++			 * buffers
++			 */
++			netmap_tx_irq(scq->channel->netdev, scq->channel->ix);
++		}
++
++		/* cq interrupts are not re-armed until the end of the
++		 * mlx5e_netmap_*sync() functions so we don't get more
++		 * interrupts if a call to those is already pending or in progress.
++		 */
++		napi_complete(napi);
++
++		/* avoid losing completion event during/after polling cqs */
++		if (test_bit(MLX5E_CHANNEL_NAPI_SCHED, &c->flags)) {
++			napi_schedule(napi); /* request another call to this func */
++		}
++
++		return 0;
++	}
++#endif
++
+ 	busy |= mlx5e_poll_rx_cq(&c->rq.cq, budget);
+ 
+ 	busy |= mlx5e_post_rx_wqes(&c->rq);

--- a/LINUX/mlx5_netmap_linux.h
+++ b/LINUX/mlx5_netmap_linux.h
@@ -1,0 +1,739 @@
+/*
+ * netmap support for Mellanox mlx5 Ethernet driver on Linux
+ *
+ * Copyright (C) 2015-2018 British Broadcasting Corporation. All rights reserved.
+ *
+ * Author: Stuart Grace, BBC Research & Development
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ *   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *   SUCH DAMAGE.
+ *
+ * Some portions are:
+ *
+ *   Copyright (C) 2012-2014 Matteo Landi, Luigi Rizzo. All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ *   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ *   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ *   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ *   SUCH DAMAGE.
+ *
+ * Some portions are:
+ *
+ *   Copyright (c) 2013-2015, Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ *       Redistribution and use in source and binary forms, with or
+ *       without modification, are permitted provided that the following
+ *       conditions are met:
+ *
+ *        - Redistributions of source code must retain the above
+ *          copyright notice, this list of conditions and the following
+ *          disclaimer.
+ *
+ *        - Redistributions in binary form must reproduce the above
+ *          copyright notice, this list of conditions and the following
+ *          disclaimer in the documentation and/or other materials
+ *          provided with the distribution.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *   SOFTWARE.
+ */
+
+#ifndef __MLX5_NETMAP_LINUX_H__
+#define __MLX5_NETMAP_LINUX_H__
+
+#include <bsd_glue.h>
+#include <net/netmap.h>
+#include <dev/netmap/netmap_kern.h>
+
+#ifdef NETMAP_MLX5_MAIN
+
+#include "en.h"
+
+#define NM_MLX5E_ADAPTER mlx5e_priv
+
+/* These functions are in en_rx.c but needed here to
+ * deal with compressed CQEs
+ */
+inline void mlx5e_read_cqe_slot(struct mlx5e_cq *cq, u32 cc, void *data);
+inline void mlx5e_write_cqe_slot(struct mlx5e_cq *cq, u32 cc, void *data);
+inline void mlx5e_decompress_cqe(struct mlx5e_cq *cq, struct mlx5_cqe64 *title,
+                                 struct mlx5_mini_cqe8 *mini, u16 wqe_counter,
+                                 int i);
+void mlx5e_decompress_cqes(struct mlx5e_cq *cq);
+
+/*
+ * Register/unregister. We are already under netmap lock.
+ * Only called on the first register or the last unregister.
+ */
+int mlx5e_netmap_reg(struct netmap_adapter *na, int onoff) {
+  struct ifnet *ifp = na->ifp;
+  struct NM_MLX5E_ADAPTER *adapter = netdev_priv(ifp);
+  int err = 0;
+  int was_opened;
+
+  D("mlx5e switching %s native netmap mode", onoff ? "into" : "out of");
+
+  /* Should we check and wait for any reset in progress to complete? */
+  mutex_lock(&adapter->state_lock);
+  was_opened = test_bit(MLX5E_STATE_OPENED, &adapter->state);
+
+  if (was_opened) {
+    mlx5e_close_locked(adapter->netdev);
+  }
+
+  /* enable or disable flags and callbacks in na and ifp */
+  if (onoff) {
+    nm_set_native_flags(na);
+  } else {
+    nm_clear_native_flags(na);
+  }
+
+  if (was_opened)
+    err = mlx5e_open_locked(adapter->netdev);
+
+  if (err)
+    netdev_err(adapter->netdev,
+               "mlx5e_netmap_reg: mlx5e_open_locked returned err code %d\n",
+               err);
+
+  mutex_unlock(&adapter->state_lock);
+
+  return err;
+}
+
+/*
+ * Reconcile kernel and user view of the transmit ring.
+ *
+ * Userspace wants to send packets up to the one before ring->head,
+ * kernel knows kring->nr_hwcur is the first unsent packet.
+ *
+ * Here we push packets out (as many as possible), and possibly
+ * reclaim buffers from previously completed transmission.
+ *
+ * ring->tail is updated on return.
+ * ring->head is never used here.
+ *
+ * The caller (netmap) guarantees that there is only one instance
+ * running at any time. Any interference with other driver
+ * methods should be handled by the individual drivers.
+ */
+int mlx5e_netmap_txsync(struct netmap_kring *kring, int flags) {
+  struct netmap_adapter *na = kring->na;
+  struct ifnet *ifp = na->ifp;
+  struct netmap_ring *ring = kring->ring;
+  u32 ring_nr = kring->ring_id;
+  u32 nm_i; /* index into the netmap ring */
+  u32 n;
+  u32 const lim = kring->nkr_num_slots - 1;
+  u32 const head = kring->rhead;
+
+  /* device-specific */
+  struct NM_MLX5E_ADAPTER *priv = netdev_priv(ifp);
+
+  struct mlx5e_sq *sq = priv->txq_to_sq_map[ring_nr];
+  struct mlx5e_cq *cq = &(sq->cq);
+  struct mlx5e_tx_wqe *wqe = NULL;
+  struct mlx5_cqe64 *cqe = NULL;
+  struct mlx5_wqe_ctrl_seg *cseg;
+  struct mlx5_wqe_eth_seg *eseg;
+  struct mlx5_wqe_data_seg *dseg;
+  u16 sqcc;
+  int cqe_found = 0;
+
+  /*
+   * If we have packets to send (kring->nr_hwcur != ring->cur)
+   * iterate over the netmap ring, fetch buffer address and length
+   * and create a suitable WQE for each packet to send.
+   *
+   * Only the last WQE requests a CQE is created to report
+   * completion.
+   */
+
+  if (!netif_carrier_ok(ifp)) {
+    goto out;
+  }
+
+  nm_i = kring->nr_hwcur;
+
+  if (nm_i != head) { /* we have new packets to send */
+
+    /* D("TX ring %u sending slots %u to %u",
+     *            ring_nr, nm_i, nm_prev(head, lim));
+     */
+
+    for (n = 0; nm_i != head; n++) {
+
+      struct netmap_slot *slot = &ring->slot[nm_i];
+      u_int len = slot->len;
+      uint64_t paddr; /* physical address for DMA */
+      void *addr = PNMB(na, slot, &paddr);
+
+      /* Code below based on mlx5e_sq_xmit() in en_tx.c */
+
+      struct mlx5_wq_cyc *wq = &sq->wq;
+      u16 pi = sq->pc & wq->sz_m1; /* producer index */
+
+      u8 opcode = MLX5_OPCODE_SEND;
+      u16 ds_cnt;
+      u16 ihs; /* inline hdr size */
+      u8 num_wqebbs = 0;
+
+      wqe = mlx5_wq_cyc_get_wqe(wq, pi);
+      cseg = &wqe->ctrl; /* ctrl seg */
+      eseg = &wqe->eth;  /* ethernet seg */
+      ds_cnt = sizeof(*wqe) / MLX5_SEND_WQE_DS;
+
+      NM_CHECK_ADDR_LEN(na, addr, len); /* limit len to buf size */
+
+      slot->flags &= ~(NS_REPORT | NS_BUF_CHANGED);
+
+      memset(wqe, 0, sizeof(*wqe));
+
+      /* request checksum generation in hw */
+      eseg->cs_flags = MLX5_ETH_WQE_L3_CSUM | MLX5_ETH_WQE_L4_CSUM;
+
+      /* Use minimum inline header to minimise data copying */
+      ihs = ETH_HLEN + 2; /* MAC + MAC + VLAN + Ethertype = 16 bytes */
+
+      if (unlikely(ihs > len))
+        ihs = len; /* whole packet fits inline */
+
+      memcpy(eseg->inline_hdr_start, addr, ihs);
+      eseg->inline_hdr_sz = cpu_to_be16(ihs);
+
+      ds_cnt +=
+          DIV_ROUND_UP(ihs - sizeof(eseg->inline_hdr_start), MLX5_SEND_WQE_DS);
+
+      dseg = (struct mlx5_wqe_data_seg *)cseg + ds_cnt;
+
+      /* Put all rest of packet into a single data segment */
+      /* excluding bytes in the inline header */
+      if (likely(len > ihs)) {
+
+        dseg->addr = cpu_to_be64(paddr + ihs); /* phys addr */
+        dseg->lkey = sq->mkey_be;
+        dseg->byte_count = cpu_to_be32(len - ihs);
+        ds_cnt++;
+      }
+
+      cseg->opmod_idx_opcode = cpu_to_be32((sq->pc << 8) | opcode);
+      cseg->qpn_ds = cpu_to_be32((sq->sqn << 8) | ds_cnt);
+
+      num_wqebbs = DIV_ROUND_UP(ds_cnt, MLX5_SEND_WQEBB_NUM_DS);
+      sq->pc += num_wqebbs;
+
+      /* Instead of storing pointer to a skb in sq->skb[pi], we use
+       * it to store info we will need at completion:
+       *   - number of wqebbs in this wqe (shifted up by 24 bits)
+       *   - slot number in the netmap kring that this wqe is sending
+       *           (in bottom 24 bits)
+       */
+      sq->skb[pi] = (void *)(uintptr_t)(nm_i & 0x00FFFFFF) +
+                    ((uintptr_t)num_wqebbs << 24);
+
+      /* fill sq edge with nops to avoid wqe wrap around */
+      while ((sq->pc & wq->sz_m1) > sq->edge)
+        mlx5e_send_nop(sq, false);
+
+      sq->stats.packets++;
+
+      /* next netmap slot */
+      nm_i = nm_next(nm_i, lim);
+    } /* next packet */
+
+    /* Wake up the hardware if any packets enqueued */
+    if (wqe) {
+      /* Request a CQE when the final WQE has completed */
+      cseg->fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
+
+      mlx5e_tx_notify_hw(sq, wqe, 0);
+    }
+
+    kring->nr_hwcur = head;
+  }
+
+  /*
+   * Second part: reclaim buffers from completed transmissions.
+   * We find these by looking for CQEs in the CQ.
+   *
+   * Code below based on mlx5e_poll_tx_cq() in en_tx.c
+   */
+
+  /* sq->cc must be updated only after mlx5_cqwq_update_db_record(),
+   * otherwise a cq overrun may occur */
+  sqcc = sq->cc;
+
+  cqe = mlx5e_get_cqe(cq);
+
+  while (cqe) {
+    u16 wqe_counter;
+    bool last_wqe;
+
+    cqe_found = 1;
+    mlx5_cqwq_pop(&cq->wq);
+    mlx5e_prefetch_cqe(cq);
+
+    /* this cqe could relate to many wqes */
+    wqe_counter = be16_to_cpu(cqe->wqe_counter);
+
+    do {
+      u16 ci = sqcc & sq->wq.sz_m1;
+      void *skb = sq->skb[ci];
+      u8 num_wqebbs;
+      u32 nm_i_done;
+
+      last_wqe = (sqcc == wqe_counter);
+
+      if (unlikely(!skb)) { /* nop */
+        sq->stats.nop++;
+        sqcc++;
+        continue;
+      }
+
+      /* unpack num_wqebbs and slot number from skb pointer */
+      num_wqebbs = (u8)((uintptr_t)skb >> 24);
+      nm_i_done = (u32)((uintptr_t)skb & 0x00FFFFFF);
+
+      sqcc += num_wqebbs;
+      kring->nr_hwtail = nm_prev(nm_i_done, lim);
+
+    } while (!last_wqe);
+
+    cqe = mlx5e_get_cqe(cq);
+  }
+
+  if (cqe_found) {
+
+    mlx5_cqwq_update_db_record(&cq->wq);
+
+    /* ensure cq space is freed before enabling more cqes */
+    wmb();
+    sq->cc = sqcc;
+  }
+
+  mlx5e_cq_arm(cq); /* allow interrupts from this CQ */
+
+out:
+  return 0;
+}
+
+/*
+ * Reconcile kernel and user view of the receive ring.
+ * Same as for the txsync, this routine must be efficient.
+ * The caller guarantees a single invocations, but races against
+ * the rest of the driver should be handled here.
+ *
+ * When called, userspace has released buffers up to ring->head
+ * (last one excluded).
+ *
+ * If (flags & NAF_FORCE_READ) also check for incoming packets irrespective
+ * of whether or not we received an interrupt.
+ */
+int mlx5e_netmap_rxsync(struct netmap_kring *kring, int flags) {
+  struct netmap_adapter *na = kring->na;
+  struct ifnet *ifp = na->ifp;
+  struct netmap_ring *ring = kring->ring;
+  u_int ring_nr = kring->ring_id;
+  u_int nm_i = 0; /* index into the netmap ring */
+  u_int const lim = kring->nkr_num_slots - 1;
+  u_int const head = kring->rhead;
+  uint16_t slot_flags = 0;
+
+  /* device-specific */
+  struct NM_MLX5E_ADAPTER *priv = netdev_priv(ifp);
+  struct mlx5e_rq *rq = &(priv->channel[ring_nr]->rq);
+  struct mlx5e_cq *cq = &(rq->cq);
+  struct mlx5_cqe64 *cqe = NULL;
+  int cqe_found = 0;
+
+  if (unlikely(rq->rq_type == RQ_TYPE_STRIDE)) {
+    netdev_err(ifp,
+               "RQ type is STRIDING - this is not supported in netmap mode\n");
+    return 0;
+  }
+
+  if (!netif_carrier_ok(ifp))
+    return 0;
+
+  if (unlikely(head > lim)) {
+    return netmap_ring_reinit(kring);
+  }
+
+  rmb();
+
+  /*
+   * first part: reclaim buffers that userspace has released:
+   *  (from kring->nr_hwcur to slot before ring->head)
+   * and make the buffers available for reception.
+   * As usual nm_i is the index in the netmap ring.
+   */
+  nm_i = kring->nr_hwcur;
+
+  if (nm_i != head) {
+
+    struct mlx5_wq_ll *wq = &rq->wq;
+    struct mlx5e_rx_wqe *wqe = mlx5_wq_ll_get_wqe(wq, wq->head);
+    struct netmap_slot *slot;
+    uint64_t paddr;
+    void *addr;
+
+    while (nm_i != head && !mlx5_wq_ll_is_full(wq)) {
+
+      slot = &ring->slot[nm_i];
+      addr = PNMB(na, slot, &paddr); /* find phys address */
+
+      if (unlikely(addr == NETMAP_BUF_BASE(na))) { /* bad buf */
+        netdev_warn(ifp, "Resetting RX ring %u in mlx5e_netmap_rxsync\n",
+                    ring_nr);
+        goto ring_reset;
+      }
+
+      if (slot->flags & NS_BUF_CHANGED) {
+        slot->flags &= ~NS_BUF_CHANGED;
+      }
+
+      wqe = mlx5_wq_ll_get_wqe(wq, wq->head);
+      wqe->data.addr = cpu_to_be64(paddr);
+
+      mlx5_wq_ll_push(wq, be16_to_cpu(wqe->next.next_wqe_index));
+
+      nm_i = nm_next(nm_i, lim);
+    }
+
+    kring->nr_hwcur = nm_i;
+
+    /* ensure wqes are visible to device before updating doorbell record */
+    wmb();
+    mlx5_wq_ll_update_db_record(wq);
+  }
+
+  /*
+   * Second part: import newly received packets.
+   * We are told about received packets by CQEs in the CQ.
+   *
+   * nm_i is the index of the next free slot in the netmap ring:
+   */
+  nm_i = kring->nr_hwtail;
+
+  cqe = mlx5e_get_cqe(cq);
+
+  while (cqe) {
+    struct mlx5e_rx_wqe *wqe;
+    u16 bytes_recv = 0;
+    __be16 wqe_id_be;
+    u16 wqe_counter;
+
+    cqe_found = 1;
+
+    if (mlx5_get_cqe_format(cqe) == MLX5_COMPRESSED)
+      mlx5e_decompress_cqes(&rq->cq);
+
+    mlx5_cqwq_pop(&cq->wq);
+    mlx5e_prefetch_cqe(cq);
+
+    wqe_id_be = cqe->wqe_counter;
+    wqe_counter = be16_to_cpu(wqe_id_be);
+    wqe = mlx5_wq_ll_get_wqe(&rq->wq, wqe_counter);
+    bytes_recv = be32_to_cpu(cqe->byte_cnt);
+
+    if (unlikely((cqe->op_own >> 4) != MLX5_CQE_RESP_SEND)) {
+      rq->stats.wqe_err++;
+      netdev_warn(ifp, "Bad response found in CQE for RQ %u\n", ring_nr);
+      goto wq_ll_pop;
+    }
+
+    rq->stats.packets++;
+    if (cqe->hds_ip_ext & CQE_L4_OK)
+      rq->stats.csum_good++;
+
+    /* could analyse checksums more thoroughly using flags in
+     * l4_hdr_type_etc that us which checksums are applicable
+     */
+    /* Following is useful during debugging:
+     *   printk(KERN_ERR "** Received %u bytes for ring %u slot %u with
+     *                    L2CSUM %s, L3CSUM %s, L4CSUM %s\n",
+     *   be32_to_cpu(cqe->byte_cnt), ring_nr, nm_i,
+     *   (cqe->hds_ip_ext & CQE_L2_OK)? "good" : "*BAD*",
+     *   (cqe->hds_ip_ext & CQE_L3_OK)? "good" : "bad or not IP",
+     *   (cqe->hds_ip_ext & CQE_L4_OK)? "good" : "bad or not TCP/UDP");
+     */
+
+    ring->slot[nm_i].len = bytes_recv;
+    ring->slot[nm_i].flags = slot_flags;
+    nm_i = nm_next(nm_i, lim);
+
+  wq_ll_pop:
+    cqe = mlx5e_get_cqe(cq);
+    mlx5_wq_ll_pop(&rq->wq, wqe_id_be, &wqe->next.next_wqe_index);
+  }
+
+  if (cqe_found) {
+    kring->nr_hwtail = nm_i;
+    mlx5_cqwq_update_db_record(&cq->wq);
+
+    /* ensure cq space is freed before enabling more cqes */
+    wmb();
+
+    /* update the kring state */
+    kring->nr_kflags &= ~NKR_PENDINTR;
+  }
+
+  mlx5e_cq_arm(cq); /* allow interrupts from this CQ */
+
+  return 0;
+
+ring_reset:
+  return netmap_ring_reinit(kring);
+}
+
+/*
+ * Acknowledge and clear all CQEs when TX queue is closing down
+ */
+int mlx5e_netmap_tx_flush(struct mlx5e_sq *sq) {
+  struct mlx5e_cq *cq = &(sq->cq);
+  struct mlx5_cqe64 *cqe;
+  u16 sqcc;
+
+  rmb();
+
+  /* sq->cc must be updated only after mlx5_cqwq_update_db_record(),
+   * otherwise a cq overrun may occur */
+  sqcc = sq->cc;
+
+  /* Any completed jobs in the CQ? */
+  cqe = mlx5e_get_cqe(cq);
+
+  while (cqe) {
+    u16 wqe_counter;
+    bool last_wqe;
+
+    mlx5_cqwq_pop(&cq->wq);
+    mlx5e_prefetch_cqe(cq);
+
+    /* this cqe could relate to many wqes */
+    wqe_counter = be16_to_cpu(cqe->wqe_counter);
+
+    do {
+      u16 ci = sqcc & sq->wq.sz_m1;
+      void *skb = sq->skb[ci];
+
+      last_wqe = (sqcc == wqe_counter);
+
+      if (unlikely(!skb)) { /* nop */
+        sq->stats.nop++;
+        sqcc++;
+        continue;
+      }
+
+      /* extract num_wqebbs from skb pointer */
+      sqcc += (u8)((uintptr_t)skb >> 24);
+
+    } while (!last_wqe);
+
+    cqe = mlx5e_get_cqe(cq);
+  }
+
+  mlx5_cqwq_update_db_record(&cq->wq);
+
+  /* ensure cq space is freed before enabling more cqes */
+  wmb();
+  sq->cc = sqcc;
+
+  return 0;
+}
+
+/*
+ * Acknowledge and clear all CQEs when RX queue is closing down
+ */
+int mlx5e_netmap_rx_flush(struct mlx5e_rq *rq) {
+  struct mlx5e_cq *cq = &(rq->cq);
+  struct mlx5_cqe64 *cqe;
+
+  rmb();
+
+  cqe = mlx5e_get_cqe(cq);
+
+  while (cqe) {
+    struct mlx5e_rx_wqe *wqe;
+    __be16 wqe_id_be;
+    u16 wqe_counter;
+
+    if (mlx5_get_cqe_format(cqe) == MLX5_COMPRESSED)
+      mlx5e_decompress_cqes(&rq->cq);
+
+    mlx5_cqwq_pop(&cq->wq);
+    mlx5e_prefetch_cqe(cq);
+
+    wqe_id_be = cqe->wqe_counter;
+    wqe_counter = be16_to_cpu(wqe_id_be);
+    wqe = mlx5_wq_ll_get_wqe(&rq->wq, wqe_counter);
+
+    cqe = mlx5e_get_cqe(cq);
+    mlx5_wq_ll_pop(&rq->wq, wqe_id_be, &wqe->next.next_wqe_index);
+  }
+
+  mlx5_cqwq_update_db_record(&cq->wq);
+
+  /* ensure cq space is freed before enabling more cqes */
+  wmb();
+
+  mlx5e_cq_arm(cq); /* allow interrupts from this CQ */
+
+  return 0;
+}
+
+/*
+ * if in netmap mode, attach the netmap buffers to the ring and return true.
+ * Otherwise return false.
+ */
+int mlx5e_netmap_configure_tx_ring(struct NM_MLX5E_ADAPTER *adapter,
+                                   int ring_nr) {
+  struct netmap_adapter *na = NA(adapter->netdev);
+  struct netmap_slot *slot;
+
+  slot = netmap_reset(na, NR_TX, ring_nr, 0);
+  if (!slot)
+    return 0; /* not in native netmap mode */
+
+  /*
+   * On some cards we would set up the slot addresses now.
+   * But on mlx5e, the address will be written to the WQ when
+   * each packet arrives in mlx5e_netmap_txsync
+   */
+
+  return 1;
+}
+
+int mlx5e_netmap_configure_rx_ring(struct mlx5e_rq *rq, int ring_nr) {
+  /*
+   * In netmap mode, we must preserve the buffers made
+   * available to userspace before the if_init()
+   * (this is true by default on the TX side, because
+   * init makes all buffers available to userspace).
+   */
+  struct netmap_adapter *na = NA(rq->netdev);
+  struct netmap_slot *slot;
+  int lim; /* number of WQEs to prepare */
+  int count = 0;
+
+  struct mlx5_wq_ll *wq = &rq->wq;
+
+  slot = netmap_reset(na, NR_RX, ring_nr, 0);
+  if (!slot)
+    return 0; /* not in native netmap mode */
+
+  lim = na->num_rx_desc - 1 - nm_kr_rxspace(&na->rx_rings[ring_nr]);
+
+  while (!mlx5_wq_ll_is_full(wq) && (count < lim)) {
+
+    struct mlx5e_rx_wqe *wqe = mlx5_wq_ll_get_wqe(wq, wq->head);
+
+    uint64_t paddr;
+    PNMB(na, slot + count, &paddr);
+
+    wqe->data.addr = cpu_to_be64(paddr);
+
+    mlx5_wq_ll_push(wq, be16_to_cpu(wqe->next.next_wqe_index));
+    count++;
+  }
+
+  D("populated %d WQEs in ring %d", count, ring_nr);
+
+  /* tell netmap how many buffers we have prepared */
+  (na->rx_rings[ring_nr]).nr_hwcur = count;
+
+  /* ensure wqes are visible to device before updating doorbell record */
+  wmb();
+  mlx5_wq_ll_update_db_record(wq);
+
+  return 1;
+}
+
+int mlx5e_netmap_config(struct netmap_adapter *na, u_int *txr, u_int *txd,
+                        u_int *rxr, u_int *rxd) {
+  struct ifnet *ifp = na->ifp;
+  struct NM_MLX5E_ADAPTER *adapter = netdev_priv(ifp);
+
+  /* each channel has 1 rx ring and a tx for each tc */
+  *txr = adapter->params.num_channels * adapter->params.num_tc;
+  *rxr = adapter->params.num_channels;
+  *txd = (1 << adapter->params.log_sq_size);
+  *rxd = (1 << adapter->params.log_rq_size);
+
+  D("TX: %d rings with %d slots;  RX: %d rings with %d slots", *txr, *txd, *rxr,
+    *rxd);
+
+  return 0;
+}
+
+/*
+ * The attach routine, called at the end of mlx5e_create_netdev(),
+ * fills the parameters for netmap_attach() and calls it.
+ * It cannot fail, in the worst case (such as no memory)
+ * netmap mode will be disabled and the driver will only
+ * operate in standard mode.
+ */
+void mlx5e_netmap_attach(struct NM_MLX5E_ADAPTER *adapter) {
+  struct netmap_adapter na;
+  bzero(&na, sizeof(na));
+
+  na.ifp = adapter->netdev;
+  na.pdev = &adapter->mdev->pdev->dev;
+  na.num_tx_desc = (1 << adapter->params.log_sq_size);
+  na.num_rx_desc = (1 << adapter->params.log_rq_size);
+  na.nm_txsync = mlx5e_netmap_txsync;
+  na.nm_rxsync = mlx5e_netmap_rxsync;
+  na.nm_register = mlx5e_netmap_reg;
+  na.nm_config = mlx5e_netmap_config;
+
+  /* each channel has 1 rx ring and a tx for each tc */
+  na.num_tx_rings = adapter->params.num_channels * adapter->params.num_tc;
+  na.num_rx_rings = adapter->params.num_channels;
+  netmap_attach(&na);
+}
+
+#endif /* NETMAP_MLX5_MAIN */
+
+#endif /* __MLX5_NETMAP_LINUX_H__ */
+
+/* end of file */


### PR DESCRIPTION
Hi,
As previously discussed, please find attached patches for the Mellanox mlx5 Ethernet driver for use with ConnectX-4 and ConnectX-5 cards (Resolves #210).

As we build things a little differently internally I've refactored our internal code to suit the netmap codebase, following the same sort of method used to pull in external Intel drivers for patching (as opposed to patching the kernel source).

Whilst I am able to build this, I haven't yet tackled the necessary changes to LINUX/default-config.mak.in_ to enable downloading and patching of the relevant tarball. I'm hoping the details below will help with this, and I'm happy to make further changes as required to make it fit in.

Build process:
* Download tgz from http://www.mellanox.com/downloads/Drivers/mlnx-en-3.3-1.0.0.0.tgz
* Unpack, then unpack from the tgz inside SOURCES/
* Patch (patch --posix --quiet --force -p1 < patches/mellanox--mlx5--3.3;)
* Run scripts/mlnx_en_patch.sh --without-mlx4 before make (using '-j\<x\>' to speed up as necessary) - this deals with detecting and patching for the current kernel within the Mellanox driver.
* This builds three ko files but only mlx_compat.ko and mlx5_core.ko are required for the ethernet driver.

Proposed resulting additions to resultant drivers.mak
```
mlx5@conf := CONFIG_MLX5
mlx5@src := tar xf /project-mcuk/ap/ipp/andrewbo/netmap/LINUX/ext-drivers/mlnx-en-3.3-1.0.0.0.tgz && tar xf /project-mcuk/ap/ipp/andrewbo/netmap/LINUX/mlnx-en-3.3-1.0.0.0/SOURCES/mlnx-en_3.3.orig.tar.gz && ln -s mlnx-en-3.3 mlx5
mlx5@patch := patches/mellanox--mlx5--3.3
```

The patches are against Mellanox driver version 3.3-1, and have been tested against various Linux kernels from 3.13 upwards, although not all the way to the most recent one. Our recent builds have been tested mostly against kernel 4.4 using Ubuntu 16.04.

In time these could be ported onto the version of the mlx5 driver which is bundled with the Linux kernel, but there isn't an exact match for v3.3-1 of the driver within the kernel, so I've not done this as yet.

I hope this is useful, and please let me know of any further modifications which might be required in order to assist with merging it.

Thanks