### PR TITLE
dkms: fix autoinstall

### DIFF
--- a/LINUX/dkms/dkms.conf
+++ b/LINUX/dkms/dkms.conf
@@ -5,7 +5,7 @@ REMAKE_INITRD=yes
 AUTOINSTALL=yes
 
 # netmap driver
-MAKE[0]=\'make\'
+MAKE[0]="'make' kernelver=$kernelver"
 BUILT_MODULE_NAME[0]=netmap
 DEST_MODULE_LOCATION[0]=/kernel/net/netmap/
 


### PR DESCRIPTION
kernelver would not be set when calling dkms autoinstall --kernelver 4.13.0-39-generic,
and the build would use `uname -r`

This would break at kernel updates