### PR TITLE
Add checksum offload capability for emulated driver

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -920,6 +920,9 @@ nm_os_catch_tx(struct netmap_generic_adapter *gna, int intercept)
 	return 0;
 }
 
+/* Used to cover cases where ETH_P_802_3_MIN is undefined */
+#define NM_ETH_P_802_3_MIN 0x0600
+
 /* Transmit routine used by generic_netmap_txsync(). Returns 0 on success
    and -1 on error (which may be packet drops or other errors). */
 int
@@ -929,6 +932,7 @@ nm_os_generic_xmit_frame(struct nm_os_gen_arg *a)
 	struct ifnet *ifp = a->ifp;
 	u_int len = a->len;
 	netdev_tx_t ret;
+	uint16_t ethertype;
 
 	/* We know that the driver needs to prepend ifp->needed_headroom bytes
 	 * to each packet to be transmitted. We then reset the mbuf pointers
@@ -947,18 +951,27 @@ nm_os_generic_xmit_frame(struct nm_os_gen_arg *a)
 	skb_reset_tail_pointer(m);
 	skb_reset_mac_header(m);
 
-	/* Initialize the header pointers assuming this is an IPv4 packet.
-	 * This is useful to make netmap interact well with TC when
-	 * netmap_generic_txqdisc == 0.  */
-	skb_set_network_header(m, 14);
-	skb_set_transport_header(m, 34);
-	m->protocol = htons(ETH_P_IP);
-	m->pkt_type = PACKET_HOST;
-
 	/* Copy a netmap buffer into the mbuf.
 	 * TODO Support the slot flags (NS_MOREFRAG, NS_INDIRECT). */
 	skb_copy_to_linear_data(m, a->addr, len); // skb_store_bits(m, 0, addr, len);
 	skb_put(m, len);
+
+	/* Initialize the header pointers assuming this is an IP packet.
+	 * This is useful to make netmap interact well with TC when
+	 * netmap_generic_txqdisc == 0.  */
+	skb_set_network_header(m, ETH_HLEN);
+	ethertype = *((uint16_t*)(m->data + ETH_ALEN * 2));
+	m->protocol = ntohs(ethertype) >= NM_ETH_P_802_3_MIN ? ethertype : htons(ETH_P_802_3);
+	m->pkt_type = PACKET_HOST;
+	m->ip_summed = CHECKSUM_NONE;
+
+	if (m->protocol == htons(ETH_P_IPV6)) {
+		skb_set_transport_header(m, ETH_HLEN + sizeof(struct nm_ipv6hdr));
+	} else if (m->protocol == htons(ETH_P_IP)) {
+		skb_set_transport_header(m, ETH_HLEN + sizeof(struct nm_iphdr));
+	} else {
+		skb_reset_transport_header(m);
+	}
 
 	/* Hold a reference on this, we are going to recycle mbufs as
 	 * much as possible. */

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -408,9 +408,15 @@ nm_os_send_up(struct ifnet *ifp, struct mbuf *m, struct mbuf *prev)
 }
 
 int
-nm_os_mbuf_has_offld(struct mbuf *m)
+nm_os_mbuf_has_csum_offld(struct mbuf *m)
 {
-	return m->ip_summed == CHECKSUM_PARTIAL || skb_is_gso(m);
+	return m->ip_summed == CHECKSUM_PARTIAL;
+}
+
+int
+nm_os_mbuf_has_seg_offld(struct mbuf *m)
+{
+	return skb_is_gso(m);
 }
 
 #ifdef WITH_GENERIC

--- a/WINDOWS/netmap_windows.c
+++ b/WINDOWS/netmap_windows.c
@@ -1017,7 +1017,13 @@ nm_os_ncpus(void)
 }
 
 int
-nm_os_mbuf_has_offld(struct mbuf *m)
+nm_os_mbuf_has_csum_offld(struct mbuf *m)
+{
+	return 0;  // TODO
+}
+
+int
+nm_os_mbuf_has_seg_offld(struct mbuf *m)
 {
 	return 0;  // TODO
 }

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -3644,10 +3644,15 @@ netmap_transmit(struct ifnet *ifp, struct mbuf *m)
 	}
 
 	if (!netmap_generic_hwcsum) {
-		if (nm_os_mbuf_has_offld(m)) {
-			RD(1, "%s drop mbuf that needs offloadings", na->name);
+		if (nm_os_mbuf_has_csum_offld(m)) {
+			RD(1, "%s drop mbuf that needs checksum offload", na->name);
 			goto done;
 		}
+	}
+
+	if (nm_os_mbuf_has_seg_offld(m)) {
+		RD(1, "%s drop mbuf that needs generic segmentation offload", na->name);
+		goto done;
 	}
 
 	/* protect against netmap_rxsync_from_host(), netmap_sw_to_nic()

--- a/sys/dev/netmap/netmap_freebsd.c
+++ b/sys/dev/netmap/netmap_freebsd.c
@@ -268,11 +268,17 @@ nm_os_send_up(struct ifnet *ifp, struct mbuf *m, struct mbuf *prev)
 }
 
 int
-nm_os_mbuf_has_offld(struct mbuf *m)
+nm_os_mbuf_has_csum_offld(struct mbuf *m)
 {
 	return m->m_pkthdr.csum_flags & (CSUM_TCP | CSUM_UDP | CSUM_SCTP |
 					 CSUM_TCP_IPV6 | CSUM_UDP_IPV6 |
-					 CSUM_SCTP_IPV6 | CSUM_TSO);
+					 CSUM_SCTP_IPV6);
+}
+
+int
+nm_os_mbuf_has_seg_offld(struct mbuf *m)
+{
+	return m->m_pkthdr.csum_flags & CSUM_TSO;
 }
 
 static void

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -1609,6 +1609,7 @@ enum {                                  /* verbose flags */
 
 extern int netmap_txsync_retry;
 extern int netmap_flags;
+extern int netmap_generic_hwcsum;
 extern int netmap_generic_mit;
 extern int netmap_generic_ringsize;
 extern int netmap_generic_rings;

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -311,7 +311,8 @@ void nm_os_vfree(void *);
  */
 void *nm_os_send_up(struct ifnet *, struct mbuf *m, struct mbuf *prev);
 
-int nm_os_mbuf_has_offld(struct mbuf *m);
+int nm_os_mbuf_has_seg_offld(struct mbuf *m);
+int nm_os_mbuf_has_csum_offld(struct mbuf *m);
 
 #include "netmap_mbq.h"
 


### PR DESCRIPTION
The following patch adds support for checksum offloading to hardware when using the emulated driver function of netmap. In our use case where netmap originates traffic (rather than the main use case of forwarding) it's useful to have this mode available as a fallback.

There's a sysctl parameter added to enable this function, which remains disabled by default.

Assuming this looks generally acceptable as a contribution, I'd appreciate a review, not least in the following two areas:
* The first commit changes where the mbuf protocol is identified from (using the location of the ethertype rather than assuming IPv4)
* The second commit disables the offloading check in netmap.c when the new sysctl parameter is enabled. This is necessary to allow CHECKSUM_PARTIAL cases to pass, but also removed the check for GSO. It may be preferred to split the function nm_os_mbuf_has_offld into two so that the GSO check remains in place.

Thanks