### PR TITLE
NAF_FORCE_RECLAIM can cause no ring buffers to be available

### DIFF
--- a/LINUX/ixgbe_netmap_linux.h
+++ b/LINUX/ixgbe_netmap_linux.h
@@ -421,10 +421,13 @@ ixgbe_netmap_txsync(struct netmap_kring *kring, int flags)
 #ifndef NM_IXGBE_USE_TDH
 	(void)reclaim_tx;
 	if ((flags & NAF_FORCE_RECLAIM) || nm_kr_txempty(kring)) {
+		u_int tail_i;
 		nic_i = NM_ACCESS_ONCE(*ina->heads[ring_nr].phead);
 		nm_i = netmap_idx_n2k(kring, nic_i);
 		ND(5, "%s: h %d", kring->name, h);
-		kring->nr_hwtail = nm_prev(nm_i, lim);
+		tail_i = nm_prev(nm_i, lim);
+		if (tail_i != kring->nr_hwcur)
+			kring->nr_hwtail = tail_i;
 	}
 #else /* NM_IXGBE_USE_TDH */
 	/*

--- a/sys/dev/netmap/netmap_vale.c
+++ b/sys/dev/netmap/netmap_vale.c
@@ -447,12 +447,19 @@ netmap_vale_attach(struct nmreq_header *hdr, void *auth_token)
 	}
 	vpna = (struct netmap_vp_adapter *)na;
 	req->port_index = vpna->bdg_port;
+
+	if (nmd)
+		netmap_mem_put(nmd);
+
 	NMG_UNLOCK();
 	return 0;
 
 unref_exit:
 	netmap_adapter_put(na);
 unlock_exit:
+	if (nmd)
+		netmap_mem_put(nmd);
+
 	NMG_UNLOCK();
 	return error;
 }

--- a/sys/dev/netmap/netmap_vale.c
+++ b/sys/dev/netmap/netmap_vale.c
@@ -447,19 +447,12 @@ netmap_vale_attach(struct nmreq_header *hdr, void *auth_token)
 	}
 	vpna = (struct netmap_vp_adapter *)na;
 	req->port_index = vpna->bdg_port;
-
-	if (nmd)
-		netmap_mem_put(nmd);
-
 	NMG_UNLOCK();
 	return 0;
 
 unref_exit:
 	netmap_adapter_put(na);
 unlock_exit:
-	if (nmd)
-		netmap_mem_put(nmd);
-
 	NMG_UNLOCK();
 	return error;
 }


### PR DESCRIPTION
When doing a force reclaim, the code blindly moves nr_hwtail.
It needs to ensure there is at least one free buffer.

It looks like all the drivers have this change.  I can do that if we decide this is the correct change.