### PR TITLE
netmap_vale_attach can leak memory references

### DIFF
--- a/sys/dev/netmap/netmap_vale.c
+++ b/sys/dev/netmap/netmap_vale.c
@@ -447,12 +447,19 @@ netmap_vale_attach(struct nmreq_header *hdr, void *auth_token)
 	}
 	vpna = (struct netmap_vp_adapter *)na;
 	req->port_index = vpna->bdg_port;
+
+	if (nmd)
+		netmap_mem_put(nmd);
+
 	NMG_UNLOCK();
 	return 0;
 
 unref_exit:
 	netmap_adapter_put(na);
 unlock_exit:
+	if (nmd)
+		netmap_mem_put(nmd);
+
 	NMG_UNLOCK();
 	return error;
 }


### PR DESCRIPTION
If netmap_vale_attach() is called with a memory region, it
will leak a reference to that region.  Make sure to do a
netmap_mem_put in this case. 

Fixes issue 559