### PR TITLE
Update help message in nmreplay

### DIFF
--- a/apps/nmreplay/nmreplay.8
+++ b/apps/nmreplay/nmreplay.8
@@ -62,7 +62,9 @@ Command line options are as follows
 .It Fl f Ar pcap-file
 Name of the pcap file to replay.
 .It Fl i Ar interface
-Name of the netmap interface to use as output.
+Name of the netmap interface to use as output. See
+.Xr netmap 4
+for interface name format.
 .It Fl v
 Enable verbose mode
 .It Fl b Ar batch-size

--- a/apps/nmreplay/nmreplay.c
+++ b/apps/nmreplay/nmreplay.c
@@ -972,7 +972,7 @@ usage(void)
 {
 	fprintf(stderr,
 	    "usage: nmreplay [-v] [-D delay] [-B {[constant,]bps|ether,bps|real,speedup}] [-L loss]\n"
-	    "\t[-b burst] -f pcap-file -i ifb\n");
+	    "\t[-b burst] -f pcap-file -i <netmap:ifname|valeSSS:PPP>\n");
 	exit(1);
 }
 


### PR DESCRIPTION
The help message in nmreplay is misleading. nmreplay will not work if you only put the interface name. It has to be preferenced with netmap: in order to work. However, if it fails you are simply told "could not open interface <interface>" which leaves the user thinking there is another problem.