### PR TITLE
mlx5: don't skip prepare step when building patched driver

### DIFF
--- a/LINUX/default-config.mak.in_
+++ b/LINUX/default-config.mak.in_
@@ -93,7 +93,7 @@ define mellanox_driver
 $(1)@fetch	:= test -e @SRCDIR@/ext-drivers/mlnx-en-$(2).tgz || wget http://content.mellanox.com/Drivers/mlnx-en-$(2).tgz -P @SRCDIR@/ext-drivers
 $(1)@src	:= tar xf @SRCDIR@/ext-drivers/mlnx-en-$(2).tgz && tar xf mlnx-en-$(2)/SOURCES/mlnx-en_$($(1)@pv).orig.tar.gz && ln -s mlnx-en-$($(1)@pv) $(1)
 $(1)@patch	:= patches/mellanox--$(1)--$($(1)@pv)
-$(1)@prepare	:= @SRCDIR@/mlx5-prepare.sh @KSRC@ @TMPDIR@
+$(1)@prepare	:= @SRCDIR@/mlx5-prepare.sh @KSRC@
 $(1)@build	:= make -C $(1) NETMAP_DRIVER_SUFFIX=@DRVSUFFIX@ EXTRA_CFLAGS="$(EXTRA_CFLAGS)"
 $(1)@install	:= make -C $(1) install_modules INSTALL_MOD_PATH=@MODPATH@ NETMAP_DRIVER_SUFFIX=@DRVSUFFIX@
 $(1)@clean	:= if [ -d $(1) ]; then make -C $(1) clean; fi NETMAP_DRIVER_SUFFIX=@DRVSUFFIX@

--- a/LINUX/mlx5-prepare.sh
+++ b/LINUX/mlx5-prepare.sh
@@ -1,15 +1,8 @@
 #!/bin/sh -x
 
 KSRC=$1
-TMPDIR=$2
 
 if [ -e mlx5/config.mk ]; then
-	exit 0
-fi
-
-if [ -e $TMPDIR/mlx5/config.mk ]; then
-	sed "s|^CWD=.*|CWD=$PWD/mlx5|" $TMPDIR/mlx5/config.mk > mlx5/config.mk
-	cp -r $TMPDIR/mlx5/compat/* mlx5/compat/
 	exit 0
 fi
 


### PR DESCRIPTION
This seems to cause build failures with more recent driver version