### PR TITLE
Add ability to change MTU once device driver is loaded.

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -1308,11 +1308,19 @@ linux_netmap_start_xmit(struct sk_buff *skb, struct net_device *dev)
 	return (NETDEV_TX_OK);
 }
 
+#define native_change_mtu(na, dev, mtu)					\
+	(((struct net_device_ops *)(na)->if_transmit)->NETMAP_LINUX_CHANGE_MTU(dev, mtu))
+
 int
 linux_netmap_change_mtu(struct net_device *dev, int new_mtu)
 {
-	return -EBUSY;
+	struct netmap_adapter *na = NA(dev);
+
+	if (netmap_buf_size_validate(na, new_mtu))
+		return -EINVAL;
+	return native_change_mtu(na, dev, new_mtu);
 }
+
 
 /* while in netmap mode, we cannot tolerate any change in the
  * number of rx/tx rings and descriptors

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -2117,6 +2117,53 @@ netmap_csb_validate(struct netmap_priv_d *priv, struct nmreq_opt_csb *csbo)
 	return 0;
 }
 
+/* Ensure that the netmap adapter can support the given MTU.
+ * @return EINVAL if the na cannot be set to mtu, 0 otherwise.
+ */
+int
+netmap_buf_size_validate(const struct netmap_adapter *na, unsigned mtu) {
+	unsigned nbs = NETMAP_BUF_SIZE(na);
+
+	if (mtu <= na->rx_buf_maxsize) {
+		/* The MTU fits a single NIC slot. We only
+		 * Need to check that netmap buffers are
+		 * large enough to hold an MTU. NS_MOREFRAG
+		 * cannot be used in this case. */
+		if (nbs < mtu) {
+			nm_prerr("error: netmap buf size (%u) "
+				 "< device MTU (%u)", nbs, mtu);
+			return EINVAL;
+		}
+	} else {
+		/* More NIC slots may be needed to receive
+		 * or transmit a single packet. Check that
+		 * the adapter supports NS_MOREFRAG and that
+		 * netmap buffers are large enough to hold
+		 * the maximum per-slot size. */
+		if (!(na->na_flags & NAF_MOREFRAG)) {
+			nm_prerr("error: large MTU (%d) needed "
+				 "but %s does not support "
+				 "NS_MOREFRAG", mtu,
+				 na->ifp->if_xname);
+			return EINVAL;
+		} else if (nbs < na->rx_buf_maxsize) {
+			nm_prerr("error: using NS_MOREFRAG on "
+				 "%s requires netmap buf size "
+				 ">= %u", na->ifp->if_xname,
+				 na->rx_buf_maxsize);
+			return EINVAL;
+		} else {
+			nm_prinf("info: netmap application on "
+				 "%s needs to support "
+				 "NS_MOREFRAG "
+				 "(MTU=%u,netmap_buf_size=%u)",
+				 na->ifp->if_xname, mtu, nbs);
+		}
+	}
+	return 0;
+}
+
+
 /*
  * possibly move the interface to netmap-mode.
  * If success it returns a pointer to netmap_if, otherwise NULL.
@@ -2226,11 +2273,10 @@ netmap_do_regif(struct netmap_priv_d *priv, struct netmap_adapter *na,
 		 */
 		if (na->ifp && nm_priv_rx_enabled(priv)) {
 			/* This netmap adapter is attached to an ifnet. */
-			unsigned nbs = NETMAP_BUF_SIZE(na);
 			unsigned mtu = nm_os_ifnet_mtu(na->ifp);
 
 			ND("%s: mtu %d rx_buf_maxsize %d netmap_buf_size %d",
-					na->name, mtu, na->rx_buf_maxsize, nbs);
+				na->name, mtu, na->rx_buf_maxsize, NETMAP_BUF_SIZE(na));
 
 			if (na->rx_buf_maxsize == 0) {
 				nm_prerr("%s: error: rx_buf_maxsize == 0", na->name);
@@ -2238,45 +2284,9 @@ netmap_do_regif(struct netmap_priv_d *priv, struct netmap_adapter *na,
 				goto err_drop_mem;
 			}
 
-			if (mtu <= na->rx_buf_maxsize) {
-				/* The MTU fits a single NIC slot. We only
-				 * Need to check that netmap buffers are
-				 * large enough to hold an MTU. NS_MOREFRAG
-				 * cannot be used in this case. */
-				if (nbs < mtu) {
-					nm_prerr("error: netmap buf size (%u) "
-						"< device MTU (%u)", nbs, mtu);
-					error = EINVAL;
-					goto err_drop_mem;
-				}
-			} else {
-				/* More NIC slots may be needed to receive
-				 * or transmit a single packet. Check that
-				 * the adapter supports NS_MOREFRAG and that
-				 * netmap buffers are large enough to hold
-				 * the maximum per-slot size. */
-				if (!(na->na_flags & NAF_MOREFRAG)) {
-					nm_prerr("error: large MTU (%d) needed "
-						"but %s does not support "
-						"NS_MOREFRAG", mtu,
-						na->ifp->if_xname);
-					error = EINVAL;
-					goto err_drop_mem;
-				} else if (nbs < na->rx_buf_maxsize) {
-					nm_prerr("error: using NS_MOREFRAG on "
-						"%s requires netmap buf size "
-						">= %u", na->ifp->if_xname,
-						na->rx_buf_maxsize);
-					error = EINVAL;
-					goto err_drop_mem;
-				} else {
-					nm_prinf("info: netmap application on "
-						"%s needs to support "
-						"NS_MOREFRAG "
-						"(MTU=%u,netmap_buf_size=%u)",
-						na->ifp->if_xname, mtu, nbs);
-				}
-			}
+			error = netmap_buf_size_validate(na, mtu);
+			if (error)
+				goto err_drop_mem;
 		}
 
 		/*

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -1454,6 +1454,7 @@ void netmap_set_all_rings(struct netmap_adapter *, int stopped);
 void netmap_disable_all_rings(struct ifnet *);
 void netmap_enable_all_rings(struct ifnet *);
 
+int netmap_buf_size_validate(const struct netmap_adapter *na, unsigned mtu);
 int netmap_do_regif(struct netmap_priv_d *priv, struct netmap_adapter *na,
 		uint32_t nr_mode, uint16_t nr_ringid, uint64_t nr_flags);
 void netmap_do_unregif(struct netmap_priv_d *priv);


### PR DESCRIPTION
If the linux interface device driver supports NS_MOREFRAG or the
new MTU still fits within a netmap buffer, allow the MTU to be
changed.