### PR TITLE
Implemented zero copy between vale ports

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -7,6 +7,7 @@ DEBUG=1
 UTILS=1
 DRVERRFAIL=
 DMASYNC=1
+VALE_ZERO_COPY=0
 
 # setelem2n <set> <elem>
 setelem2n()
@@ -280,6 +281,7 @@ replace_vars()
 		-e "s|@DESTDIR@|$DESTDIR|g" \
 		-e "s|@DEBUG@|$DEBUG|g" \
 		-e "s|@UTILS@|$UTILS|g" \
+		-e "s|@VALE_ZERO_COPY@|$VALE_ZERO_COPY|g" \
 		$1
 }
 
@@ -329,6 +331,7 @@ Available options:
   --no-force-debug	       build the modules w/ or w/o debug symbols,
   --cache=		       dir for reusing/caching of netmap_linux_config.h
   --without-dmasync	       use this if you are on x86 with a recent NIC and no IOMMU
+  --vale-zero-copy	       enable zero copy between nic and host rings
 
   --cc=                        C compiler to be used for the apps and utils [$cc]
   --ld=                        linker to be used for the apps and utils [$ld]
@@ -649,6 +652,9 @@ for opt do
 		;;
 	--without-dmasync)
 		DMASYNC=
+		;;
+	--vale-zero-copy)
+		VALE_ZERO_COPY=1
 		;;
 	*)
 		echo "Unrecognized option: $opt" | warning

--- a/LINUX/netmap.mak.in
+++ b/LINUX/netmap.mak.in
@@ -10,6 +10,7 @@ SUBSYS:=@SUBSYS@
 SRCDIR:=@SRCDIR@
 BUILDDIR:=@BUILDDIR@
 DEBUG:=@DEBUG@
+VALE_ZERO_COPY:=@VALE_ZERO_COPY@
 
 # The following commands are needed to build the modules as out-of-tree,
 # in fact the kernel sources path must be specified.
@@ -36,6 +37,10 @@ S_DRIVERS = @S_DRIVERS@
 E_DRIVERS = @E_DRIVERS@
 DRVSUFFIX = @DRVSUFFIX@
 UTILS = @UTILS@
+
+ifeq (1,$(VALE_ZERO_COPY))
+EXTRA_CFLAGS += -DVALE_ZERO_COPY
+endif
 
 ifeq (,$(DRVSUFFIX))
 else

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -2079,6 +2079,7 @@ void nm_os_mitigation_cleanup(struct nm_generic_mit *mit);
  */
 struct nm_bdg_fwd {	/* forwarding entry for a bridge */
 	void *ft_buf;		/* netmap or indirect buffer */
+	struct netmap_slot *ft_src_slot;	/* original slot - for zero copy */
 	uint8_t ft_frags;	/* how many fragments (only on 1st frag) */
 	uint16_t ft_offset;	/* dst port (unused) */
 	uint16_t ft_flags;	/* flags, e.g. indirect */


### PR DESCRIPTION
Implemented zero copy between vale ports for better performance. Zero copy of packet will be done as long as :
- it is not to a broadcast packet, and
- the source and dest ports are in the same memory region.

Also, provided a compile time option to turn zero copy mode ON/OFF.