### PR TITLE
bdg config interface locking

### DIFF
--- a/sys/dev/netmap/netmap_bdg.c
+++ b/sys/dev/netmap/netmap_bdg.c
@@ -906,10 +906,10 @@ netmap_bdg_config(struct nm_ifreq *nr)
 	}
 	NMG_UNLOCK();
 	/* Don't call config() with NMG_LOCK() held */
-	BDG_RLOCK(b);
+	BDG_WLOCK(b);
 	if (b->bdg_ops.config != NULL)
 		error = b->bdg_ops.config(nr);
-	BDG_RUNLOCK(b);
+	BDG_WUNLOCK(b);
 	return error;
 }
 


### PR DESCRIPTION
Since bdg config interface is supposed to be used for updating the configuration of the module (e.g. updating the routing table), I think it should take writer lock instead of reader lock.