### PR TITLE
Use size_t instead of u_int for total memory.

### DIFF
--- a/extra/python/netmap_manager.c
+++ b/extra/python/netmap_manager.c
@@ -154,7 +154,7 @@ NetmapManager_repr(NetmapManager *self)
             "dev_name:  '%s'\n"
             "if_name:   '%s'\n"
             "version:   %d\n"
-            "memsize:   %u KiB\n"
+            "memsize:   %zu KiB\n"
             "offset:    %u\n"
             "tx_slots:  %d\n"
             "rx_slots:  %d\n"

--- a/share/man/man4/netmap.4
+++ b/share/man/man4/netmap.4
@@ -552,7 +552,7 @@ struct nmreq {
     char      nr_name[IFNAMSIZ]; /* (i) port name                  */
     uint32_t  nr_version;        /* (i) API version                */
     uint32_t  nr_offset;         /* (o) nifp offset in mmap region */
-    uint32_t  nr_memsize;        /* (o) size of the mmap region    */
+    size_t    nr_memsize;        /* (o) size of the mmap region    */
     uint32_t  nr_tx_slots;       /* (i/o) slots in tx rings        */
     uint32_t  nr_rx_slots;       /* (i/o) slots in rx rings        */
     uint16_t  nr_tx_rings;       /* (i/o) number of tx rings       */

--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -100,16 +100,17 @@ struct netmap_obj_pool {
 	/* ---------------------------------------------------*/
 	/* these are only meaningful if the pool is finalized */
 	/* (see 'finalized' field in netmap_mem_d)            */
-	u_int objtotal;         /* actual total number of objects. */
-	u_int memtotal;		/* actual total memory space */
-	u_int numclusters;	/* actual number of clusters */
-
-	u_int objfree;          /* number of free objects. */
+	size_t memtotal;	/* actual total memory space */
 
 	struct lut_entry *lut;  /* virt,phys addresses, objtotal entries */
 	uint32_t *bitmap;       /* one bit per buffer, 1 means free */
 	uint32_t *invalid_bitmap;/* one bit per buffer, 1 means invalid */
 	uint32_t bitmap_slots;	/* number of uint32 entries in bitmap */
+
+	u_int objtotal;         /* actual total number of objects. */
+	u_int numclusters;	/* actual number of clusters */
+	u_int objfree;          /* number of free objects. */
+
 	int	alloc_done;	/* we have allocated the memory */
 	/* ---------------------------------------------------*/
 
@@ -159,7 +160,7 @@ struct netmap_mem_ops {
 
 struct netmap_mem_d {
 	NMA_LOCK_T nm_mtx;  /* protect the allocator */
-	u_int nm_totalsize; /* shorthand */
+	size_t nm_totalsize; /* shorthand */
 
 	u_int flags;
 #define NETMAP_MEM_FINALIZED	0x1	/* preallocation done */
@@ -817,7 +818,7 @@ netmap_mem2_ofstophys(struct netmap_mem_d* nmd, vm_ooffset_t offset)
 		return pa;
 	}
 	/* this is only in case of errors */
-	nm_prerr("invalid ofs 0x%x out of 0x%x 0x%x 0x%x", (u_int)o,
+	nm_prerr("invalid ofs 0x%x out of 0x%zx 0x%zx 0x%zx", (u_int)o,
 		p[NETMAP_IF_POOL].memtotal,
 		p[NETMAP_IF_POOL].memtotal
 			+ p[NETMAP_RING_POOL].memtotal,
@@ -947,7 +948,7 @@ netmap_mem2_get_info(struct netmap_mem_d* nmd, uint64_t* size,
 			*size = 0;
 			for (i = 0; i < NETMAP_POOLS_NR; i++) {
 				struct netmap_obj_pool *p = nmd->pools + i;
-				*size += (p->_numclusters * p->_clustsize);
+				*size += ((size_t)p->_numclusters * (size_t)p->_clustsize);
 			}
 		}
 	}
@@ -1476,9 +1477,9 @@ netmap_finalize_obj_allocator(struct netmap_obj_pool *p)
 #endif
 		}
 	}
-	p->memtotal = p->numclusters * p->_clustsize;
+	p->memtotal = (size_t)p->numclusters * (size_t)p->_clustsize;
 	if (netmap_verbose)
-		nm_prinf("Pre-allocated %d clusters (%d/%dKB) for '%s'",
+		nm_prinf("Pre-allocated %d clusters (%d/%zuKB) for '%s'",
 		    p->numclusters, p->_clustsize >> 10,
 		    p->memtotal >> 10, p->name);
 
@@ -1639,7 +1640,7 @@ netmap_mem_finalize_all(struct netmap_mem_d *nmd)
 	nmd->flags |= NETMAP_MEM_FINALIZED;
 
 	if (netmap_verbose)
-		nm_prinf("interfaces %d KB, rings %d KB, buffers %d MB",
+		nm_prinf("interfaces %zd KB, rings %zd KB, buffers %zd MB",
 		    nmd->pools[NETMAP_IF_POOL].memtotal >> 10,
 		    nmd->pools[NETMAP_RING_POOL].memtotal >> 10,
 		    nmd->pools[NETMAP_BUF_POOL].memtotal >> 20);
@@ -2341,8 +2342,8 @@ netmap_mem_ext_create(uint64_t usrptr, struct nmreq_pools_info *pi, int *perror)
 		}
 		p->objtotal = j;
 		p->numclusters = p->objtotal;
-		p->memtotal = j * p->_objsize;
-		nm_prdis("%d memtotal %u", j, p->memtotal);
+		p->memtotal = j * (size_t)p->_objsize;
+		nm_prdis("%d memtotal %zu", j, p->memtotal);
 	}
 
 	netmap_mem_ext_register(nme);
@@ -2573,7 +2574,7 @@ netmap_mem_pt_guest_finalize(struct netmap_mem_d *nmd)
 
 	ptnmd->buf_lut.objtotal = nbuffers;
 	ptnmd->buf_lut.objsize = bufsize;
-	nmd->nm_totalsize = (unsigned int)mem_size;
+	nmd->nm_totalsize = mem_size;
 
 	/* Initialize these fields as are needed by
 	 * netmap_mem_bufsize().

--- a/sys/net/netmap_legacy.h
+++ b/sys/net/netmap_legacy.h
@@ -152,7 +152,7 @@ struct nmreq {
 	char		nr_name[IFNAMSIZ];
 	uint32_t	nr_version;	/* API version */
 	uint32_t	nr_offset;	/* nifp offset in the shared region */
-	uint32_t	nr_memsize;	/* size of the shared region */
+	size_t	        nr_memsize;	/* size of the shared region */
 	uint32_t	nr_tx_slots;	/* slots in tx rings */
 	uint32_t	nr_rx_slots;	/* slots in rx rings */
 	uint16_t	nr_tx_rings;	/* number of tx rings */

--- a/sys/net/netmap_user.h
+++ b/sys/net/netmap_user.h
@@ -117,7 +117,7 @@
 		(nifp)->ni_host_tx_rings] )
 
 #define NETMAP_BUF(ring, index)				\
-	((char *)(ring) + (ring)->buf_ofs + ((index)*(ring)->nr_buf_size))
+	((char *)(ring) + (ring)->buf_ofs + ((size_t)(index)*(ring)->nr_buf_size))
 
 #define NETMAP_BUF_IDX(ring, buf)			\
 	( ((char *)(buf) - ((char *)(ring) + (ring)->buf_ofs) ) / \
@@ -254,7 +254,7 @@ struct nm_desc {
 	struct nm_desc *self; /* point to self if netmap. */
 	int fd;
 	void *mem;
-	uint32_t memsize;
+	size_t memsize;
 	int done_mmap;	/* set if mem is the result of mmap */
 	struct netmap_if * const nifp;
 	uint16_t first_tx_ring, last_tx_ring, cur_tx_ring;

--- a/utils/ctrl-api-test.c
+++ b/utils/ctrl-api-test.c
@@ -206,7 +206,7 @@ port_info_get(struct TestContext *ctx)
 		perror("ioctl(/dev/netmap, NIOCCTRL, PORT_INFO_GET)");
 		return ret;
 	}
-	printf("nr_memsize %llu\n", (unsigned long long)req.nr_memsize);
+	printf("nr_memsize %zu\n", req.nr_memsize);
 	printf("nr_tx_slots %u\n", req.nr_tx_slots);
 	printf("nr_rx_slots %u\n", req.nr_rx_slots);
 	printf("nr_tx_rings %u\n", req.nr_tx_rings);
@@ -265,7 +265,7 @@ port_register(struct TestContext *ctx)
 		return ret;
 	}
 	printf("nr_offset 0x%llx\n", (unsigned long long)req.nr_offset);
-	printf("nr_memsize %llu\n", (unsigned long long)req.nr_memsize);
+	printf("nr_memsize %zu\n", req.nr_memsize);
 	printf("nr_tx_slots %u\n", req.nr_tx_slots);
 	printf("nr_rx_slots %u\n", req.nr_rx_slots);
 	printf("nr_tx_rings %u\n", req.nr_tx_rings);
@@ -339,7 +339,7 @@ niocregif(struct TestContext *ctx, int netmap_api)
 	}
 
 	printf("nr_offset 0x%x\n", req.nr_offset);
-	printf("nr_memsize  %u\n", req.nr_memsize);
+	printf("nr_memsize  %zu\n", req.nr_memsize);
 	printf("nr_tx_slots %u\n", req.nr_tx_slots);
 	printf("nr_rx_slots %u\n", req.nr_rx_slots);
 	printf("nr_tx_rings %u\n", req.nr_tx_rings);

--- a/utils/testmmap.c
+++ b/utils/testmmap.c
@@ -1036,11 +1036,11 @@ do_nmr_legacy_dump()
 	printf("name:      %s\n", nmr_name);
 	printf("version:   %d\n", curr_nmr.nr_version);
 	printf("offset:    %d\n", curr_nmr.nr_offset);
-	printf("memsize:   %d [", curr_nmr.nr_memsize);
+	printf("memsize:   %zu [", curr_nmr.nr_memsize);
 	if (curr_nmr.nr_memsize < (1 << 20)) {
-		printf("%d KiB", curr_nmr.nr_memsize >> 10);
+		printf("%zu KiB", curr_nmr.nr_memsize >> 10);
 	} else {
-		printf("%d MiB", curr_nmr.nr_memsize >> 20);
+		printf("%zu MiB", curr_nmr.nr_memsize >> 20);
 	}
 	printf("]\n");
 	printf("tx_slots:  %d\n", curr_nmr.nr_tx_slots);


### PR DESCRIPTION
In testing, when using buf_num over 420,000 or so, with the default
clusternumbers, we run into integer overflow and segfault. 

In our environment, we have 40 core servers (20+20) with the nics using
40 tx/rx rings, with the ring slot size set to 4096. We have to set the
buf_num to about 750000 in order to allocate enough memory for our
application to load with around 100000 extra buffers.

This segfaults without this change.

This is basically adapted from issue #602. I left the max buffers at the
default of 1_000_000 and changed some %lu and %ld to %zu %zd