### PR TITLE
remove compiler warnings when building for arm32

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -1824,8 +1824,11 @@ nm_os_pt_memdev_iomap(struct ptnetmap_memdev *ptn_dev, vm_paddr_t *nm_paddr,
 	*mem_size = ioread32(ptn_dev->pci_io + PTNET_MDEV_IO_MEMSIZE_HI);
 	*mem_size = ioread32(ptn_dev->pci_io + PTNET_MDEV_IO_MEMSIZE_LO) |
 		(*mem_size << 32);
-
+#ifdef __arm__
+	nm_prinf("=== BAR %d start %x len %x mem_size %lx ===",
+#else
 	nm_prinf("=== BAR %d start %llx len %llx mem_size %lx ===",
+#endif
 			PTNETMAP_MEM_PCI_BAR,
 			pci_resource_start(pdev, PTNETMAP_MEM_PCI_BAR),
 			pci_resource_len(pdev, PTNETMAP_MEM_PCI_BAR),

--- a/LINUX/netmap_ptnet.c
+++ b/LINUX/netmap_ptnet.c
@@ -1270,7 +1270,11 @@ ptnet_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 	}
 
 	err = -EIO;
+#ifdef __arm__
+	pr_info("%s: IO BAR (registers): start 0x%x, len %u, flags 0x%lx\n",
+#else
 	pr_info("%s: IO BAR (registers): start 0x%llx, len %llu, flags 0x%lx\n",
+#endif
 		__func__, pci_resource_start(pdev, PTNETMAP_IO_PCI_BAR),
 		pci_resource_len(pdev, PTNETMAP_IO_PCI_BAR),
 		pci_resource_flags(pdev, PTNETMAP_IO_PCI_BAR));
@@ -1352,14 +1356,18 @@ ptnet_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
 		/* CSB allocation protocol. Write to GH_BAH first, then
 		 * to GH_BAL. Same for HG_BAH and HG_BAL. */
 		phys_addr_t paddr = virt_to_phys(pi->csb_gh);
+#ifndef __arm__
 		iowrite32((paddr >> 32) & 0xffffffff,
-				ioaddr + PTNET_IO_CSB_GH_BAH);
+		        ioaddr + PTNET_IO_CSB_GH_BAH);
+#endif
 		iowrite32(paddr & 0xffffffff,
 				ioaddr + PTNET_IO_CSB_GH_BAL);
 
 		paddr = virt_to_phys(pi->csb_hg);
+#ifndef __arm__
 		iowrite32((paddr >> 32) & 0xffffffff,
 				ioaddr + PTNET_IO_CSB_HG_BAH);
+#endif
 		iowrite32(paddr & 0xffffffff,
 				ioaddr + PTNET_IO_CSB_HG_BAL);
 	}

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -3316,7 +3316,7 @@ nmreq_getoption(struct nmreq_header *hdr, uint16_t reqtype)
 	if (!hdr->nr_options)
 		return NULL;
 
-	opt_tab = (struct nmreq_option **)(hdr->nr_options) - (NETMAP_REQ_OPT_MAX + 1);
+	opt_tab = (struct nmreq_option **)((uintptr_t)hdr->nr_options) - (NETMAP_REQ_OPT_MAX + 1);
 	return opt_tab[reqtype];
 }
 


### PR DESCRIPTION
Small modifications to build netmap.ko on arm32 without compiler warnings
Tested arm32 platform: imx6
Compiler: gcc-linaro-7.3.1-2018.05 (https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/arm-linux-gnueabihf/)

Steps I followed:
1. ./configure --no-drivers --no-ext-drivers --kernel-sources=$PATH2KERNELSRC --kernel-dir=$PATH2KERNELSRC --kernel-opts="ARCH=arm CROSS_COMPILE=/opt/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-" --cc=/opt/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc --ld=/opt/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf/bin/arm-linux-gnueabihf-ld --driver-suffix=-netmap

2. make netmap.ko
