### PR TITLE
Fixing build error when building on Debian Buster

### DIFF
--- a/apps/lb/lb.c
+++ b/apps/lb/lb.c
@@ -652,7 +652,7 @@ int main(int argc, char **argv)
 	/* extract the base name */
 	char *nscan = strncmp(glob_arg.ifname, "netmap:", 7) ?
 			glob_arg.ifname : glob_arg.ifname + 7;
-	strncpy(glob_arg.base_name, nscan, MAX_IFNAMELEN);
+	strncpy(glob_arg.base_name, nscan, MAX_IFNAMELEN -1);
 	for (nscan = glob_arg.base_name; *nscan && !index("-*^{}/@", *nscan); nscan++)
 		;
 	*nscan = '\0';


### PR DESCRIPTION
Fixing build error when building on Debian Buster
 Ensuring glob_arg.base_name stays null terminated
cc (Debian 8.3.0-6) 8.3.0

make[1]: Entering directory '/home/dev/code/netmap/LINUX/build-apps/lb'
cc -O2 -pipe -Werror -Wall -Wunused-function -I /home/dev/code/netmap/LINUX/../sys -I /home/dev/code/netmap/LINUX/../apps/include -Wextra   -c -o lb.o /home/dev/code/netmap/LINUX/../apps/lb/lb.c
/home/dev/code/netmap/LINUX/../apps/lb/lb.c: In function ‘main’:
/home/dev/code/netmap/LINUX/../apps/lb/lb.c:655:2: error: ‘strncpy’ specified bound 64 equals destination size [-Werror=stringop-truncation]
  strncpy(glob_arg.base_name, nscan, MAX_IFNAMELEN);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors