### PR TITLE
Record mapped netmap memory as RssShmem rather than RssFile

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -1252,6 +1252,7 @@ linux_netmap_fault(struct vm_fault *vmf)
 	if (!pfn_valid(pfn))
 		return VM_FAULT_SIGBUS;
 	page = pfn_to_page(pfn);
+	SetPageSwapBacked(page);
 	get_page(page);
 	vmf->page = page;
 	return 0;


### PR DESCRIPTION
 VmRSS     size of memory portions. It contains the three
           following parts (VmRSS = RssAnon + RssFile + RssShmem)
 RssAnon   size of resident anonymous memory
 RssFile   size of resident file mappings
 RssShmem  size of resident shmem memory (includes SysV shm,
           mapping of tmpfs and shared anonymous mappings)

The kernel differentiates between RssFile and RssShmem by
checking the PG_swapbacked flag on the page. By setting this
flag the netmp memory will be recorded as RssShmem.