### PR TITLE
linux/configure: check for struct timeval

### DIFF
--- a/LINUX/bsd_glue.h
+++ b/LINUX/bsd_glue.h
@@ -440,6 +440,13 @@ struct nm_linux_selrecord_t;
 
 #define	tsleep(a, b, c, t)	msleep(10)
 
+#ifndef NETMAP_LINUX_HAVE_STRUCT_TIMEVAL
+struct timeval {
+	long	tv_sec;		/* seconds */
+	long	tv_usec;	/* microseconds */
+};
+#endif /* !NETMAP_LINUX_HAVE_STRUCT_TIMEVAL */
+
 #define microtime		do_gettimeofday		/* debugging */
 #ifndef NETMAP_LINUX_HAVE_DO_GETTIMEOFDAY
 #define do_gettimeofday(tv_)					\

--- a/LINUX/configure
+++ b/LINUX/configure
@@ -1740,6 +1740,18 @@ EOF
 	}
 EOF
 
+  # is struct timeval defined?
+  add_test 'have STRUCT_TIMEVAL' << EOF
+	#include <linux/time.h>
+
+	void
+	dummy(struct timeval *tv) {
+		tv->tv_sec = 0;
+		tv->tv_usec = 0;
+		return;
+	}
+EOF
+
   add_test 'have DO_GETTIMEOFDAY' <<EOF
 	#include <linux/time.h>
 


### PR DESCRIPTION
As of Linux v5.6 struct timeval does not exist (in the kernel). Detect
this and define our own when needed.

Fixes #689

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>