### PR TITLE
fix NETMAP_WOFFSET and typos

### DIFF
--- a/libnetmap/libnetmap.h
+++ b/libnetmap/libnetmap.h
@@ -252,11 +252,11 @@ int nmport_inject(struct nmport_d *d, const void *buf, size_t size);
  * The relation among the functions is as follows:
  *
  *				   |nmport_new
- * 		|nport_prepare	 = |
+ * 		|nmport_prepare	 = |
  *		|		   |nmport_parse
  * nmport_open =|
  *		|		   |nmport_register
- *		|nport_open_desc = |
+ *		|nmport_open_desc =|
  *				   |nmport_mmap
  *
  */
@@ -449,7 +449,7 @@ struct nmreq_pools_info* nmport_extmem_getinfo(struct nmport_d *d);
  * The user may also declare a @mingap (ignored if zero) if she plans to use
  * offsets to share the same buffer among several slots. Netmap will guarantee
  * that it will never write more than @mingap bytes for each slot, irrespective
- * of the buffer lenght.
+ * of the buffer length.
  */
 int nmport_offset(struct nmport_d *d, uint64_t initial, uint64_t maxoff,
 		uint64_t bits, uint64_t mingap);

--- a/sys/net/netmap_user.h
+++ b/sys/net/netmap_user.h
@@ -130,7 +130,7 @@
 /* update the offset field in a ring's slot */
 #define NETMAP_WOFFSET(ring, slot, offset)		\
 	do { (slot)->ptr = ((slot)->ptr & ~(ring)->offset_mask) | \
-		((offset) & (ring)->offset_mask) } while (0)
+		((offset) & (ring)->offset_mask); } while (0)
 
 /* obtain the start of the buffer pointed to by  a ring's slot, taking the
  * offset field into accout


### PR DESCRIPTION
@giuseppelettieri I fixed the macro from https://github.com/luigirizzo/netmap/commit/a2b1b4ea221a63626ff4b1bfa07c6c356da28434#commitcomment-39365274

I also found a few typos in libnetmap.h, I hope that you dont mind

Note that I didn't actually test the offset support. I'm just experimenting with some of the netmap features. I'm using i40e and it looks like offset is just implemented in e1000