### PR TITLE
fix parsing of legacy nmr->nr_ringid

### DIFF
--- a/sys/dev/netmap/netmap_legacy.c
+++ b/sys/dev/netmap/netmap_legacy.c
@@ -76,9 +76,9 @@ nmreq_register_from_legacy(struct nmreq *nmr, struct nmreq_header *hdr,
 		/* Convert the older nmr->nr_ringid (original
 		 * netmap control API) to nmr->nr_flags. */
 		u_int regmode = NR_REG_DEFAULT;
-		if (req->nr_ringid & NETMAP_SW_RING) {
+		if (nmr->nr_ringid & NETMAP_SW_RING) {
 			regmode = NR_REG_SW;
-		} else if (req->nr_ringid & NETMAP_HW_RING) {
+		} else if (nmr->nr_ringid & NETMAP_HW_RING) {
 			regmode = NR_REG_ONE_NIC;
 		} else {
 			regmode = NR_REG_ALL_NIC;


### PR DESCRIPTION
Code was checking for NETMAP_{SW,HW}_RING in req->nr_ringid which
had already been masked by NETMAP_RING_MASK. Therefore, the comparisons
always failed and set NR_REG_ALL_NIC. Check against the original nmr
structure.