### PR TITLE
linux: Use GFP_USER for contiguous memory allocation

### DIFF
--- a/LINUX/bsd_glue.h
+++ b/LINUX/bsd_glue.h
@@ -416,7 +416,7 @@ static inline int ilog2(uint64_t n)
 #define contigmalloc(sz, ty, flags, a, b, pgsz, c) ({		\
 	unsigned int order_ =					\
 		ilog2(roundup_pow_of_two(sz)/PAGE_SIZE);	\
-	struct page *p_ = alloc_pages(GFP_ATOMIC | __GFP_ZERO,  \
+	struct page *p_ = alloc_pages(GFP_USER | __GFP_ZERO,  \
 		order_);					\
 	if (p_ != NULL) 					\
 		split_page(p_, order_);				\


### PR DESCRIPTION
GFP_ATOMIC prevents memory reclaim. In the scenario where the device
has been running for a while the number of free pages can be low,
but the file cache can be large. Without allowing memory reclaim
we would get "page allocation failures".

https://github.com/luigirizzo/netmap/issues/673