### PR TITLE
netmap.h/freebsd: Include <atomic> instead of <stdatomic.h> when compiling with C++

### DIFF
--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -832,7 +832,16 @@ static inline void nm_ldld_barrier(void)
 #define nm_ldld_barrier	atomic_thread_fence_acq
 #define nm_stld_barrier	atomic_thread_fence_seq_cst
 #else  /* !_KERNEL */
+
+#ifdef __cplusplus
+#include <atomic>
+using std::memory_order_release;
+using std::memory_order_acquire;
+
+#else /* __cplusplus */
 #include <stdatomic.h>
+#endif /* __cplusplus */
+
 static inline void nm_stst_barrier(void)
 {
 	atomic_thread_fence(memory_order_release);


### PR DESCRIPTION
Compiling the following C++ program on FreeBSD (11.4 / 12.1) currently fails.
This affects the netmap plugin for Zeek [1].

    $ cat test_netmap.cc
    #include <iostream>

    extern "C" {
    #define NETMAP_WITH_LIBS
    #include <net/netmap_user.h>
    }

    int main(int argc, char *argv[])
    {
            std::cout << "netmap" << std::endl;
    }

    $ clang++  ./test_netmap.cc
    In file included from ./test_netmap.cc:5:
    In file included from /usr/include/net/netmap_user.h:100:
    In file included from /usr/include/net/netmap.h:814:
    /usr/include/stdatomic.h:187:17: error: unknown type name '_Bool'
    typedef _Atomic(_Bool)                  atomic_bool;
                    ^
    /usr/include/stdatomic.h:187:26: error: C++ requires a type specifier for all declarations
    typedef _Atomic(_Bool)                  atomic_bool;

Similar issues [2,3] (though GCC) suggest to use `<atomic>` instead
of `<stdatomic.h>` for C++.

[1] https://github.com/zeek/bro-netmap/issues/11
[2] https://bugs.python.org/issue23644
[3] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60932#c4