### PR TITLE
freebsd: fix mutex double unlock

### DIFF
--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -2023,7 +2023,6 @@ netmap_mem2_if_new(struct netmap_mem_d *nmd,
 	len = sizeof(struct netmap_if) + (ntot * sizeof(ssize_t));
 	nifp = netmap_if_malloc(nmd, len);
 	if (nifp == NULL) {
-		NMA_UNLOCK(nmd);
 		return NULL;
 	}
 


### PR DESCRIPTION
Hello,

I am testing FreeBSD-12.2-RC3 using a kernel with INVARIANTS enabled. I was starting pkt-gen on an interface with a large number of rings and had forgotten to increase the if_size sysctl. A memory allocation failed and the system hit a panic.

Panic message:
```
Lock (&nm_mem)->nm_mtx not exclusively locked @ /usr/src/sys/dev/netmap/netmap_mem2.c:271
```