### PR TITLE
Fix BUG_ON() in Linux on vxlan/gretap/hyper-v interfaces

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -959,7 +959,7 @@ nm_os_generic_xmit_frame(struct nm_os_gen_arg *a)
 	netdev_tx_t ret;
 	uint16_t ethertype;
 
-	/* We know that the driver needs to prepend ifp->needed_headroom bytes
+	/* We know that the driver needs to prepend LL_RESERVED_SPACE(ifp) bytes
 	 * to each packet to be transmitted. We then reset the mbuf pointers
 	 * to the correct initial state:
 	 *    ___________________________________________
@@ -969,10 +969,10 @@ nm_os_generic_xmit_frame(struct nm_os_gen_arg *a)
 	 *               tail
 	 *
 	 * which correspond to an empty buffer with exactly
-	 * ifp->needed_headroom bytes between head and data.
+	 * LL_RESERVED_SPACE(ifp) bytes between head and data.
 	 */
 	m->len = 0;
-	m->data = m->head + ifp->needed_headroom;
+	m->data = m->head + LL_RESERVED_SPACE(ifp);
 	skb_reset_tail_pointer(m);
 	skb_reset_mac_header(m);
 

--- a/sys/dev/netmap/netmap_generic.c
+++ b/sys/dev/netmap/netmap_generic.c
@@ -106,7 +106,7 @@ __FBSDID("$FreeBSD: head/sys/dev/netmap/netmap_generic.c 274353 2014-11-10 20:19
 static inline struct mbuf *
 nm_os_get_mbuf(struct ifnet *ifp, int len)
 {
-	return alloc_skb(ifp->needed_headroom + len +
+	return alloc_skb(LL_RESERVED_SPACE(ifp) + len +
 			 ifp->needed_tailroom, GFP_ATOMIC);
 }
 


### PR DESCRIPTION
Wrong headroom calculations lead to pskb_expand_head() in the drivers.
It fails since skb is shared. Correct calculations prevent
expanding skb.