### PR TITLE
Append to ldflags instead of assignation

### DIFF
--- a/apps/pkt-gen/GNUmakefile
+++ b/apps/pkt-gen/GNUmakefile
@@ -14,7 +14,7 @@ CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I $(SRCDIR)/libnetmap
 CFLAGS += -Wextra -Wno-address-of-packed-member
 
-LDFLAGS = -L $(BUILDDIR)/build-libnetmap
+LDFLAGS += -L $(BUILDDIR)/build-libnetmap
 LDLIBS += -lpthread -lm -lnetmap
 ifeq ($(shell uname),Linux)
 	LDLIBS += -lrt	# on linux


### PR DESCRIPTION
All the other apps append to the `LDFLAGS` variable, but not the `pkt-gen` application. Without this, it is impossible to use the environment variable to configure this variable.