### PR TITLE
stmmac: add stmmac port

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -112,7 +112,7 @@ subsys enable null
 subsys enable ptnetmap
 
 # available drivers
-driver_avail="r8169.c virtio_net.c forcedeth.c veth.c \
+driver_avail="stmmac_eth r8169.c virtio_net.c forcedeth.c veth.c \
 	e1000 e1000e igb ixgbe ixgbevf i40e vmxnet3 mlx5"
 # enabled drivers (bitfield)
 driver=
@@ -883,7 +883,7 @@ EOF
 		message " NOTE  " <<EOF
 We are trying to download the original sources for driver
 $d using the following command:
-  
+
   $drv_fetch
 
 If this fails, please download the above file and put it
@@ -927,17 +927,21 @@ EOF
 Since the generic driver has been disabled, the corresponding NICs
 will NOT be usable by netmap.
 EOF
-				fi 
+				fi
 			} | warning
 			else
 				src=$(cd $src; pwd)
 				src_found=1
-			fi 
+			fi
 			src_checked=1
 		fi
 		drv_kernel_src=
 		if [ -n "$src_found" ]; then
-			drv_kernel_src=$(find $src/drivers/ -name "$d" -print -quit)
+			if [ "$d" = "stmmac_eth" ]; then
+				drv_kernel_src=$(find $src/drivers/ -name "stmmac" -print -quit)
+			else
+				drv_kernel_src=$(find $src/drivers/ -name "$d" -print -quit)
+			fi
 		fi
 		if [ -z "$drv_kernel_src" ]; then
 			drverror <<EOF
@@ -1046,7 +1050,7 @@ else
 	drverror <<EOF
 There were problems copying the sources of driver $1.
 
-If you need this driver, please check that the $1@src variable 
+If you need this driver, please check that the $1@src variable
 points to the correct path contaning the driver sources.
 
 Disabling $1.
@@ -1072,7 +1076,7 @@ Disabling $1.
 EOF
 	drv disable $1
 	edrv disable $1
-  }	
+  }
 
   for d in $(edrv print); do
 	if !(cdrv enabled $d); then
@@ -1089,7 +1093,7 @@ There were problems patching the driver $1.
 Disabling $1.
 EOF
 	drv disable $1
-  }	
+  }
 
   for d in $(drv print); do
 	  edrv enabled $d && continue
@@ -1176,7 +1180,7 @@ EOF
   for n in 2 3 4; do
   	add_test "define SELECT_QUEUE $n" <<EOF
   		#include <linux/netdevice.h>
-  
+
   		u16 dummy(struct net_device_ops *ndo)
   		{
   		        return ndo->ndo_select_queue($params);
@@ -1823,66 +1827,66 @@ EOF
   #####################################################
   # checks related to drivers                         #
   #####################################################
-  
+
   # e1000e
   if drv enabled e1000e; then
-  
+
   add_file_exists_check e1000e/e1000.h true "drv_source_error e1000e"
-  
+
   add_test 'have E1000E_HWADDR' <<EOF
   	#include "e1000e/e1000.h"
-  
+
   	void* dummy(struct e1000_adapter *adapter,
   	        struct e1000_ring *ring)
   	{
   		return adapter->hw.hw_addr + ring->tail;
   	}
 EOF
-  
+
   add_test 'have E1000E_DOWN2' <<EOF
   	#include "e1000e/e1000.h"
-  
+
   	void dummy(struct e1000_adapter *adapter)
   	{
   		e1000e_down(adapter, false);
   	}
 EOF
-  
+
   add_test "grep -q '\<e1000_rx_desc_extended\>' $TMPDIR/e1000e/netdev.c \
   	&& have E1000E_EXT_RXDESC" </dev/null
   fi # e1000e
-  
+
   # rtl8169
   if drv enabled r8169.c; then
-  
+
   add_file_exists_check r8169.c true "drv_source_error r8169.c"
-  
+
   add_test 'define RTL_OPEN rtl8169_open' 'define RTL_OPEN rtl_open' <<EOF
   	#include "r8169.c"
-  
+
   	static int dummy(struct net_device *dev) {
   		return rtl8169_open(dev);
   	}
 EOF
-  
+
   add_test 'have RTL_WFQ' <<EOF
   	#include "r8169.c"
-  
+
   	static void dummy(struct net_device *dev) {
   		rtl8169_wait_for_quiescence(dev);
   	}
 EOF
   fi # r8169.c
-  
+
   # ixgbe
   if drv enabled ixgbe; then
-  
+
   add_file_exists_check ixgbe/ixgbe.h true "drv_source_error ixgbe"
-  
+
   # different versions of IXGBE_?X_DESC
   add_test 'define IXGBE_DESC 1' <<EOF
   	#include "ixgbe/ixgbe.h"
-  
+
   	union ixgbe_adv_tx_desc *
   	dummy(struct ixgbe_ring *ring) {
   		return IXGBE_TX_DESC_ADV(*ring, 0);
@@ -1890,7 +1894,7 @@ EOF
 EOF
   add_test 'define IXGBE_DESC 2' <<EOF
   	#include "ixgbe/ixgbe.h"
-  
+
   	union ixgbe_adv_tx_desc *
   	dummy(struct ixgbe_ring *ring) {
   		return IXGBE_TX_DESC_ADV(ring, 0);
@@ -1898,17 +1902,17 @@ EOF
 EOF
   add_test 'define IXGBE_DESC 3' <<EOF
   	#include "ixgbe/ixgbe.h"
-  
+
   	union ixgbe_adv_tx_desc *
   	dummy(struct ixgbe_ring *ring) {
   		return IXGBE_TX_DESC(ring, 0);
   	}
 EOF
-  
+
   # array of rings or array of poiners to rings?
   add_test 'define IXGBE_PTR_ARRAY' <<EOF
   	#include "ixgbe/ixgbe.h"
-  
+
   	struct ixgbe_ring *
   	dummy(struct ixgbe_adapter *adapter) {
   		return adapter->tx_ring[0];
@@ -1964,7 +1968,7 @@ EOF
   # array of rings or array of poiners to rings?
   add_test 'define IXGBEVF_PTR_ARRAY' <<EOF
   	#include "ixgbevf/ixgbevf.h"
-  
+
   	struct ixgbevf_ring *
   	dummy(struct ixgbevf_adapter *adapter) {
   		return adapter->tx_ring[0];
@@ -1987,9 +1991,9 @@ EOF
     if edrv enabled virtio_net.c; then
         VNETDIR="virtio_net.c/"
     fi
-  
+
     add_file_exists_check ${VNETDIR}virtio_net.c true "drv_source_error virtio_net.c"
-  
+
     add_test 'define VIRTIO_NET_HDR_FROM_SKB_5ARGS' <<EOF
 	#include <linux/virtio_net.h>
 
@@ -2148,45 +2152,45 @@ EOF
 
     add_test 'define VIRTIO_CB_DELAYED' <<EOF
   	#include <linux/virtio.h>
-  
+
   	bool
   	dummy(struct virtqueue *vq) {
   		return virtqueue_enable_cb_delayed(vq);
   	}
 EOF
-  
+
     add_test 'define VIRTIO_GET_VRSIZE' <<EOF
   	#include <linux/virtio.h>
-  
+
   	unsigned int
   	dummy(struct virtqueue *vq) {
   		return virtqueue_get_vring_size(vq);
   	}
 EOF
-  
+
     add_test 'define VIRTIO_FREE_PAGES' <<EOF
 	#include "${VNETDIR}virtio_net.c"
-  
+
   	void
   	dummy(struct virtnet_info *vi) {
   		free_receive_bufs(vi);
   	}
 EOF
-  
+
     add_test 'define VIRTIO_FUNCTIONS' <<EOF
   	#include <linux/virtio.h>
-  
+
   	void
   	dummy(struct virtqueue *vq) {
   		(void)virtqueue_kick(vq);
   	}
 EOF
-  
+
     for s in "" _gfp; do
   	f="virtqueue_add_buf$s"
   	add_test "define VIRTIO_ADD_BUF $f" <<EOF
   		#include <linux/virtio.h>
-  
+
   		int
   		dummy(struct virtqueue *vq, struct scatterlist sg[],
   			unsigned int out_num, unsigned int in_num,
@@ -2196,43 +2200,43 @@ EOF
   		}
 EOF
   done
-  
+
     add_test 'define VIRTIO_MULTI_QUEUE' <<EOF
 	#include "${VNETDIR}virtio_net.c"
-  
+
   	struct virtqueue *
   	dummy(struct virtnet_info *vi) {
   		return vi->rq[0].vq;
   	}
 EOF
-  
+
     add_test 'define VIRTIO_RQ_NUM' <<EOF
 	#include "${VNETDIR}virtio_net.c"
-  
+
   	int
   	dummy(struct virtnet_info *vi) {
   		return vi->rq[0].num;
   	}
 EOF
-  
+
     add_test 'define VIRTIO_SG' <<EOF
 	#include "${VNETDIR}virtio_net.c"
-  
+
   	struct scatterlist *
   	dummy(struct virtnet_info *vi) {
   		return vi->rx_sg;
   	}
 EOF
-  
+
      add_test 'define VIRTIO_NOTIFY' <<EOF
   	#include <linux/virtio.h>
-  
+
   	void
   	dummy(struct virtqueue *_vq) {
   		(void)virtqueue_notify(_vq);
   	}
 EOF
-  
+
      add_test 'have GET_LINK_KSETTINGS' <<EOF
 	#include <linux/ethtool.h>
 
@@ -2244,17 +2248,17 @@ EOF
 EOF
 
   fi # virtio-net
-  
+
   if drv enabled i40e; then
     add_test 'define I40E_PTR_ARRAY' <<EOF
   	#include "i40e/i40e.h"
-  
+
   	struct i40e_ring *
   	dummy(struct i40e_vsi *vsi) {
   		return vsi->tx_rings[0];
   	}
 EOF
-   
+
    add_test 'define I40E_PTR_STATE' <<EOF
    	#include "i40e/i40e.h"
 	#include <linux/bitops.h>
@@ -2286,17 +2290,17 @@ EOF
        }
 EOF
   fi # igb
-  
+
   # END_TESTS
-  
+
   # now we actually create the file
-  
+
   rm -f $configh
   cat > $configh <<EOF
   	#ifndef NETMAP_LINUX_CONFIG_H
   	#define NETMAP_LINUX_CONFIG_H
 EOF
-  
+
   # the TESTPOSTPROC script will add macros to $configh
   message " NOTE  " <<EOF
 Now running compile tests to adapt the code to your
@@ -2304,7 +2308,7 @@ kernel version. Please wait.
 EOF
   run_tests
 
-# check for exported split_page 
+# check for exported split_page
   cat >> config.log <<EOF
 ##############################################################################
 ## CHECKING FOR split_page
@@ -2328,15 +2332,15 @@ EOF
   if [ -n "$DMASYNC" ]; then
 	  have DMASYNC
   fi
-  
+
   define DRIVER_SUFFIX \"$drvsuffix\"
-  
+
   # file end
   cat >> $configh <<EOF
-  
+
   	#endif
 EOF
-  
+
   if [ -d "$cache" ]; then
   	cp $configh "$cache"
   fi

--- a/LINUX/if_stmmac_netmap_linux.h
+++ b/LINUX/if_stmmac_netmap_linux.h
@@ -1,0 +1,467 @@
+/*
+ * Copyright (C) 2021 Savoir-faire Linux, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * $Id: if_stmmac_netmap_linux.h 10679 2021-01-18 13:42:18E SFL $
+ *
+ * netmap support for: stmmac (re, linux version)
+ * For details on netmap support please see ixgbe_netmap.h
+ * 1 tx ring, 1 rx ring, 1 lock, crcstrip ? reinit tx addr,
+ */
+
+#include <bsd_glue.h>
+#include <net/netmap.h>
+#include <netmap/netmap_kern.h>
+
+static int stmmac_open(struct net_device *dev);
+static int stmmac_release(struct net_device *dev);
+
+#ifdef MODULENAME
+#undef MODULENAME
+#define MODULENAME "stmmac" NETMAP_LINUX_DRIVER_SUFFIX
+#endif
+
+/*
+ * Register/unregister, mostly the reinit task
+ */
+static int stmmac_netmap_reg(struct netmap_adapter *na, int onoff)
+{
+	struct ifnet *ifp = na->ifp;
+	int error = 0;
+
+	stmmac_release(ifp);
+
+	/* enable or disable flags and callbacks in na and ifp */
+	if (onoff) {
+		nm_set_native_flags(na);
+
+		if (stmmac_open(ifp) < 0) {
+			error = ENOMEM;
+			goto fail;
+		}
+	} else {
+	fail:
+		nm_clear_native_flags(na);
+		error = stmmac_open(ifp) ? EINVAL : 0;
+	}
+
+	return (error);
+}
+
+/*
+ * Reconcile kernel and user view of the transmit ring.
+ */
+static int stmmac_netmap_txsync(struct netmap_kring *kring, int flags)
+{
+	struct netmap_adapter *na = kring->na;
+	struct ifnet *ifp = na->ifp;
+	struct netmap_ring *ring = kring->ring;
+	u_int nm_i; /* index into the netmap ring */
+	u_int nic_i; /* index into the NIC ring */
+	u_int n;
+	u_int const lim = kring->nkr_num_slots - 1;
+	u_int const head = kring->rhead;
+
+	/* device-specific */
+	struct stmmac_priv *stmac_priv = netdev_priv(ifp);
+
+	rmb();
+
+	/*
+	* First part: process new packets to send.
+	*/
+	if (!netif_carrier_ok(ifp)) {
+		goto out;
+	}
+
+	nm_i = kring->nr_hwcur;
+	/* we have new packets to send */
+	if (nm_i != head) {
+		nic_i = netmap_idx_k2n(kring, nm_i);
+		for (n = 0; nm_i != head; n++) {
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			int len = slot->len;
+			uint64_t paddr;
+			void *addr = PNMB(na, slot, &paddr);
+			uint32_t etdes1 =
+				(slot->len & ETDES1_BUFFER1_SIZE_MASK);
+			uint32_t etdes0 = ETDES0_LAST_SEGMENT | ETDES0_OWN |
+					  ETDES0_FIRST_SEGMENT;
+
+			/* device-specific */
+			struct dma_desc *pdam_desc = NULL;
+			if (stmac_priv->extend_desc)
+				pdam_desc =
+					(struct dma_desc *)(stmac_priv->dma_etx +
+							    nic_i);
+			else
+				pdam_desc = stmac_priv->dma_tx + nic_i;
+
+			NM_CHECK_ADDR_LEN(na, addr, len);
+
+			if (nic_i == lim) /* mark end of ring */
+				etdes0 |= ETDES0_END_RING;
+
+			if (slot->flags & NS_BUF_CHANGED) {
+				/* buffer has changed, reload map */
+				// netmap_reload_map(pdev, DMA_TO_DEVICE, old_paddr, addr);
+				pdam_desc->des2 = paddr;
+			}
+
+			slot->flags &= ~(NS_REPORT | NS_BUF_CHANGED);
+			pdam_desc->des0 = etdes0;
+			pdam_desc->des1 = etdes1;
+
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+
+		kring->nr_hwcur = head;
+
+		stmac_priv->cur_tx = nic_i;
+		wmb(); /* synchronize writes to the NIC ring */
+	}
+
+	/*
+	* Second part: reclaim buffers for completed transmissions.
+	*/
+	if (flags & NAF_FORCE_RECLAIM || nm_kr_txempty(kring)) {
+		for (n = 0, nic_i = stmac_priv->dirty_tx;
+		     nic_i != stmac_priv->cur_tx; n++) {
+			struct dma_desc *pdam_desc = NULL;
+			if (stmac_priv->extend_desc)
+				pdam_desc =
+					(struct dma_desc *)(stmac_priv->dma_etx +
+							    nic_i);
+			else
+				pdam_desc = stmac_priv->dma_tx + nic_i;
+
+			/* check if DMA owned */
+			if (pdam_desc->des0 & ETDES0_OWN)
+				break;
+
+			if (++nic_i == na->num_tx_desc)
+				nic_i = 0;
+		}
+
+		if (n > 0) {
+			stmac_priv->dirty_tx = nic_i;
+			kring->nr_hwtail =
+				nm_prev(netmap_idx_n2k(kring, nic_i), lim);
+		}
+	}
+out:
+	return 0;
+}
+
+/*
+ * Reconcile kernel and user view of the receive ring.
+ * static int stmmac_rx(struct stmmac_priv *priv, int limit)
+ */
+static int stmmac_netmap_rxsync(struct netmap_kring *kring, int flags)
+{
+	struct netmap_adapter *na = kring->na;
+	struct ifnet *ifp = na->ifp;
+	struct stmmac_priv *stmac_priv = netdev_priv(ifp);
+	struct netmap_ring *ring = kring->ring;
+	unsigned int nm_i; /* index into the netmap ring */
+	unsigned int entry; /* index into the NIC ring */
+	unsigned int n;
+	unsigned int const lim = kring->nkr_num_slots - 1;
+	unsigned int const head = kring->rhead;
+
+	int force_update =
+		(flags & NAF_FORCE_READ) || kring->nr_kflags & NKR_PENDINTR;
+
+	if (!netif_carrier_ok(ifp))
+		return 0;
+
+	if (head > lim)
+		return netmap_ring_reinit(kring);
+
+	rmb();
+
+	/*
+	* First part: import newly received packets.
+	*/
+	if (netmap_no_pendintr || force_update) {
+		uint32_t stop_i = nm_prev(kring->nr_hwcur, lim);
+		int coe = stmac_priv->hw->rx_csum;
+		uint32_t frame_len = 0x0;
+
+		entry = stmac_priv->cur_rx; /* next pkt to check */
+		nm_i = netmap_idx_n2k(kring, entry);
+
+		while (nm_i != stop_i) {
+			int status;
+			struct dma_desc *pdam_desc;
+
+			if (stmac_priv->extend_desc)
+				pdam_desc =
+					(struct dma_desc *)(stmac_priv->dma_erx +
+							    entry);
+			else
+				pdam_desc = stmac_priv->dma_rx + entry;
+
+			/* read the status of the incoming frame */
+			status = stmac_priv->hw->desc->rx_status(
+				&stmac_priv->dev->stats, &stmac_priv->xstats,
+				pdam_desc);
+
+			/* check if managed by the DMA otherwise go ahead */
+			if (unlikely(status & dma_own))
+				break;
+
+			if ((stmac_priv->extend_desc) &&
+			    (stmac_priv->hw->desc->rx_extended_status))
+				stmac_priv->hw->desc->rx_extended_status(
+					&stmac_priv->dev->stats,
+					&stmac_priv->xstats,
+					stmac_priv->dma_erx + entry);
+
+			frame_len = stmac_priv->hw->desc->get_rx_frame_len(
+				pdam_desc, coe);
+
+			/* ACS is set; GMAC core strips PAD/FCS for IEEE 802.3
+			 * Type frames (LLC/LLC-SNAP)
+			 */
+			if (unlikely(status != llc_snap))
+				frame_len -= ETH_FCS_LEN;
+
+			ring->slot[nm_i].len = frame_len;
+			ring->slot[nm_i].flags = 0;
+
+			nm_i = nm_next(nm_i, lim);
+			entry = nm_next(entry, lim);
+		}
+
+		stmac_priv->cur_rx = entry;
+
+		kring->nr_hwtail = nm_i;
+		kring->nr_kflags &= ~NKR_PENDINTR;
+	}
+
+	/*
+	* Second part: skip past packets that userspace has released.
+	*/
+	nm_i = kring->nr_hwcur;
+	if (nm_i != head) {
+		entry = netmap_idx_k2n(kring, nm_i);
+		for (n = 0; nm_i != head; n++) {
+			uint32_t erdes1 = 0x0;
+
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			uint64_t paddr;
+			void *addr = PNMB(na, slot, &paddr);
+
+			struct dma_desc *pdam_desc;
+
+			if (stmac_priv->extend_desc)
+				pdam_desc =
+					(struct dma_desc *)(stmac_priv->dma_erx +
+							    entry);
+			else
+				pdam_desc = stmac_priv->dma_rx + entry;
+
+			erdes1 = NETMAP_BUF_SIZE(na);
+
+			if (addr == NETMAP_BUF_BASE(na)) /* bad buf */
+				goto ring_reset;
+
+			if (entry == lim) /* mark end of ring */
+				erdes1 |= ERDES1_END_RING;
+
+			if (slot->flags & NS_BUF_CHANGED) {
+				/* buffer has changed, reload map */
+				// netmap_reload_map(pdev, DMA_TO_DEVICE, old_paddr, addr);
+				pdam_desc->des2 = paddr;
+				slot->flags &= ~NS_BUF_CHANGED;
+			}
+
+			pdam_desc->des1 |= erdes1;
+
+			nm_i = nm_next(nm_i, lim);
+			entry = nm_next(entry, lim);
+		}
+
+		kring->nr_hwcur = head;
+		wmb();
+	}
+
+	return 0;
+
+ring_reset:
+	return netmap_ring_reinit(kring);
+}
+
+/*
+ * Make the Tx desc rings point to the netmap buffers.
+ * static int init_dma_desc_rings(struct net_device *dev, gfp_t flags)
+ */
+static int stmmac_netmap_tx_init(struct stmmac_priv *stmac_priv)
+{
+	struct netmap_adapter *na = NA(stmac_priv->dev);
+	struct netmap_slot *slot = NULL;
+	int i, l;
+	uint64_t paddr = 0x0;
+
+	slot = netmap_reset(na, NR_TX, 0, 0);
+	if (!slot)
+		return 0;
+
+	/* l points in the netmap ring, i points in the NIC ring */
+	for (i = 0; i < na->num_tx_desc; i++) {
+		uint32_t etdes0 = 0x0;
+		struct dma_desc *pdam_desc = NULL;
+
+		stmac_priv->tx_skbuff[i] = NULL;
+		if (stmac_priv->extend_desc)
+			pdam_desc = &((stmac_priv->dma_etx + i)->basic);
+
+		else
+			pdam_desc = stmac_priv->dma_tx + i;
+
+		if (IS_ERR(pdam_desc))
+			return 0;
+
+		l = netmap_idx_n2k(na->tx_rings[0], i);
+		PNMB(na, slot + l, &paddr);
+
+		/* ETDES2 */
+		pdam_desc->des2 = paddr;
+
+		/* ETDES0 */
+		if (i == na->num_tx_desc - 1)
+			etdes0 |= ETDES0_END_RING;
+
+		pdam_desc->des0 = etdes0;
+	}
+
+	return 1;
+}
+
+/*
+ * Make the Rx desc rings point to the netmap buffers.
+ * static int init_dma_desc_rings(struct net_device *dev, gfp_t flags)
+ */
+static int stmmac_netmap_rx_init(struct stmmac_priv *stmac_priv)
+{
+	struct netmap_adapter *na = NA(stmac_priv->dev);
+	struct netmap_slot *slot = NULL;
+	int i, lim, l;
+	uint64_t paddr = 0x0;
+
+	slot = netmap_reset(na, NR_RX, 0, 0);
+	if (!slot)
+		return 0;
+
+	lim = na->num_rx_desc - nm_kr_rxspace(na->rx_rings[0]);
+	for (i = 0; i < na->num_rx_desc; i++) {
+		void *addr;
+		uint32_t erdes1 = 0x0;
+		struct dma_desc *pdam_desc = NULL;
+
+		stmac_priv->rx_skbuff[i] = NULL;
+
+		if (stmac_priv->extend_desc)
+			pdam_desc = &((stmac_priv->dma_erx + i)->basic);
+		else
+			pdam_desc = stmac_priv->dma_rx + i;
+
+		if (IS_ERR(pdam_desc))
+			return 0;
+
+		l = netmap_idx_n2k(na->rx_rings[0], i);
+		addr = PNMB(na, slot + l, &paddr);
+
+		/* NOTE:is not set: ERDES3 and erdes1 |= ((BUF_SIZE_8KiB - 1) << ERDES1_BUFFER2_SIZE_SHIFT) & ERDES1_BUFFER2_SIZE_MASK; */
+
+		/* ERDES2 */
+		pdam_desc->des2 = paddr;
+
+		/* ERDES1 */
+		erdes1 |=
+			((NETMAP_BUF_SIZE(na) - 1) & ERDES1_BUFFER1_SIZE_MASK);
+
+		/* operate in ring mode only, and set last ERDES accordingly*/
+		if (i == na->num_rx_desc - 1) {
+			erdes1 |= ERDES1_END_RING;
+		}
+
+		erdes1 |= ERDES1_DISABLE_IC;
+
+		pdam_desc->des1 |= erdes1;
+
+		/* ERDES0 */
+		if (i < lim)
+			pdam_desc->des0 |= RDES0_OWN;
+	}
+
+	return 1;
+}
+
+static int stmmac_netmap_bufcfg(struct netmap_kring *kring, uint64_t target)
+{
+	kring->hwbuf_len = BUF_SIZE_8KiB;
+	kring->buf_align = 0; /* no alignment */
+
+	return 0;
+}
+
+static int stmmac_netmap_config(struct netmap_adapter *na,
+				struct nm_config_info *info)
+{
+	struct stmmac_priv *stmac_priv = netdev_priv(na->ifp);
+	int ret = netmap_rings_config_get(na, info);
+
+	if (ret)
+		return ret;
+
+	info->rx_buf_maxsize = stmac_priv->dma_buf_sz;
+
+	return 0;
+}
+
+static void stmmac_netmap_attach(struct stmmac_priv *stmac_priv)
+{
+	struct netmap_adapter na;
+
+	bzero(&na, sizeof(na));
+
+	na.ifp = stmac_priv->dev; /* struct net_device *dev; */
+	na.pdev = &stmac_priv->device; /* struct device *device; */
+	na.num_tx_desc = DMA_TX_SIZE;
+	na.num_rx_desc = DMA_RX_SIZE;
+	na.rx_buf_maxsize = BUF_SIZE_8KiB;
+	na.num_tx_rings = na.num_rx_rings = 1;
+	na.nm_txsync = stmmac_netmap_txsync;
+	na.nm_rxsync = stmmac_netmap_rxsync;
+	na.nm_register = stmmac_netmap_reg;
+	na.nm_config = stmmac_netmap_config;
+	na.nm_bufcfg = stmmac_netmap_bufcfg;
+	netmap_attach(&na);
+}
+
+/* end of file */

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -1105,6 +1105,12 @@ nm_os_generic_find_num_desc(struct ifnet *ifp, unsigned int *tx, unsigned int *r
 			*tx = netmap_generic_ringsize;
 		}
 		error = 0;
+	}else{
+#define DMA_TX_SIZE 512
+#define DMA_RX_SIZE 512
+		*tx = DMA_TX_SIZE;
+		*rx = DMA_RX_SIZE;
+		error = 0;
 	}
 #endif /* HAVE_GET_RINGPARAM */
 	return error;

--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -2511,7 +2511,7 @@ start_threads(struct glob_arg *g) {
 	 * using a single descriptor.
 	 */
 	for (i = 0; i < g->nthreads; i++) {
-		uint64_t seed = time(0) | (time(0) << 32);
+		uint64_t seed = (uint64_t)time(0) | ((uint64_t)time(0) << 32);
 		t = &targs[i];
 
 		bzero(t, sizeof(*t));

--- a/libnetmap/nmctx.c
+++ b/libnetmap/nmctx.c
@@ -45,6 +45,7 @@
 static void
 nmctx_default_error(struct nmctx *ctx, const char *errmsg)
 {
+	(void)ctx;
 	fprintf(stderr, "%s\n", errmsg);
 }
 

--- a/libnetmap/nmport.c
+++ b/libnetmap/nmport.c
@@ -176,6 +176,7 @@ struct nmport_extmem_from_file_cleanup_d {
 void nmport_extmem_from_file_cleanup(struct nmport_cleanup_d *c,
 		struct nmport_d *d)
 {
+	(void)d;
 	struct nmport_extmem_from_file_cleanup_d *cc =
 		(struct nmport_extmem_from_file_cleanup_d *)c;
 
@@ -657,7 +658,7 @@ nmport_mmap(struct nmport_d *d)
 	struct nmctx *ctx = d->ctx;
 	struct nmem_d *m = NULL;
 	u_int num_tx, num_rx;
-	int i;
+	unsigned int i;
 
 	if (d->mmap_done) {
 		errno = EINVAL;

--- a/sys/dev/netmap/netmap_mem2.c
+++ b/sys/dev/netmap/netmap_mem2.c
@@ -330,7 +330,7 @@ netmap_mem_get_id(struct netmap_mem_d *nmd)
 
 /* circular list of all existing allocators */
 static struct netmap_mem_d *netmap_last_mem_d = &nm_mem;
-NM_MTX_T nm_mem_list_lock;
+static NM_MTX_T nm_mem_list_lock;
 
 struct netmap_mem_d *
 __netmap_mem_get(struct netmap_mem_d *nmd, const char *func, int line)
@@ -524,7 +524,7 @@ static struct netmap_obj_params netmap_min_priv_params[NETMAP_POOLS_NR] = {
 		.num  = 4,
 	},
 	[NETMAP_BUF_POOL] = {
-		.size = 2048,
+		.size = 2048,	/* we are using 'size = 4096,' so that native mode works with mtu >= 3800 */
 		.num  = 4098,
 	},
 };
@@ -571,7 +571,7 @@ struct netmap_mem_d nm_mem = {	/* Our memory allocator. */
 			.num  = 200,
 		},
 		[NETMAP_BUF_POOL] = {
-			.size = 2048,
+			.size = 2048,	/* again  we are using '.size = 4096,' for mtu >= 3800 */
 			.num  = NETMAP_BUF_MAX_NUM,
 		},
 	},
@@ -1534,10 +1534,10 @@ netmap_mem_unmap(struct netmap_obj_pool *p, struct netmap_adapter *na)
 	struct netmap_lut *lut;
 	if (na == NULL || na->pdev == NULL)
 		return 0;
-	
+
 	lut = &na->na_lut;
 
-	
+
 
 #if defined(__FreeBSD__)
 	/* On FreeBSD mapping and unmapping is performed by the txsync


### PR DESCRIPTION
RFC

1. add stmmac netmap support (linux version), and

2. fix compiler warning when cross building the driver with:
arm-buildroot-linux-gnueabihf-gcc (Buildroot 2019.02.2-g0b3ebc6ca5-dirty) 8.3.0