### PR TITLE
i40e: Ignore zero length packets

### DIFF
--- a/LINUX/i40e_netmap_linux.h
+++ b/LINUX/i40e_netmap_linux.h
@@ -569,6 +569,9 @@ i40e_netmap_rxsync(struct netmap_kring *kring, int flags)
 			slot->len = ((qword & I40E_RXD_QW1_LENGTH_PBUF_MASK)
 			    >> I40E_RXD_QW1_LENGTH_PBUF_SHIFT) - crclen;
 
+			if (!slot->len)
+				break;
+
 			if (unlikely((staterr & (1<<I40E_RX_DESC_STATUS_EOF_SHIFT)) == 0 )) {
 				slot_flags = NS_MOREFRAG;
 			} else {


### PR DESCRIPTION
Buffers that claim to have zero length packets aren't ready yet.
See 0e626ff7ccbfc and d57c0e08c7016 in linux.