### PR TITLE
fix compilation on Raspberry Pi

### DIFF
--- a/apps/tlem/tlem.c
+++ b/apps/tlem/tlem.c
@@ -153,6 +153,7 @@ prod()
 #include <unistd.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <libnetmap.h>
 
 
@@ -796,7 +797,7 @@ struct arp_table_entry {
 void
 arp_table_entry_dump(int idx, struct arp_table_entry *e)
 {
-    ED("%d: next %lu addr %02x:%02x:%02x:%02x:%02x:%02x",
+    ED("%d: next %" PRIu64 " addr %02x:%02x:%02x:%02x:%02x:%02x",
             idx, e->next_req,
             (uint8_t)~e->ether_addr[0],
             (uint8_t)~e->ether_addr[1],
@@ -2512,7 +2513,7 @@ skip_args:
 	}
 #ifdef WITH_MAX_LAG
         if (invdopt['d']->arg[i] != NULL) {
-            unsigned long max_lag = parse_time(invdopt[(int)'d']->arg[i]);
+            uint64_t max_lag = parse_time(invdopt[(int)'d']->arg[i]);
             if (max_lag == U_PARSE_ERR) {
                 err++;
             } else {

--- a/sys/net/netmap_user.h
+++ b/sys/net/netmap_user.h
@@ -1131,7 +1131,7 @@ nm_dispatch(struct nm_desc *d, int cnt, nm_cb_t cb, u_char *arg)
 				slot = &ring->slot[i];
 				d->hdr.len += slot->len;
 				nbuf = (u_char *)NETMAP_BUF(ring, slot->buf_idx);
-				if (oldbuf != NULL && nbuf - oldbuf == ring->nr_buf_size &&
+				if (oldbuf != NULL && (uint32_t)(nbuf - oldbuf) == ring->nr_buf_size &&
 						oldlen == ring->nr_buf_size) {
 					d->hdr.caplen += slot->len;
 					oldbuf = nbuf;

--- a/utils/testmmap.c
+++ b/utils/testmmap.c
@@ -1421,7 +1421,7 @@ nmr_body_dump_register(void *b)
 		break;
 	}
 	printf("]\n");
-	printf("flags:     %lx [", r->nr_flags);
+	printf("flags:     %" PRIx64 " [", r->nr_flags);
 #define pflag(f)                                                               \
 	if (r->nr_flags & NR_##f) {                                            \
 		printf("%s" #f, flags++ ? ", " : "");                          \
@@ -1515,7 +1515,7 @@ do_register_flags()
 	}
 	if (n)
 		curr_register.nr_flags = flags;
-	output("flags=%lx", curr_register.nr_flags);
+	output("flags=%" PRIx64, curr_register.nr_flags);
 }
 
 struct cmd_def register_commands[] = {


### PR DESCRIPTION
This fixes those 32/64-bit type mismatch errors when compiling on the Pi.