### PR TITLE
Fix assymetry in reference counter updates of memory allocator

### DIFF
--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -994,10 +994,12 @@ netmap_mem_restore(struct netmap_adapter *na)
 static void
 netmap_mem_drop(struct netmap_adapter *na)
 {
-	/* if the native allocator had been overridden on regif,
-	 * restore it now and drop the temporary one
-	 */
-	if (netmap_mem_deref(na->nm_mem, na)) {
+	netmap_mem_deref(na->nm_mem, na);
+
+	if (na->active_fds <= 0) {
+		/* if the native allocator had been overridden on regif,
+		 * restore it now and drop the temporary one
+		 */
 		netmap_mem_restore(na);
 	}
 }


### PR DESCRIPTION
I have the following issue:

I make use of the EXTMEM option to provide a user space managed memory region to netmap. If I open only a single file/interface, everything works fine. But if I open /dev/netmap twice, for putting two different interfaces in netmap mode, and I provide the same memory region to both files/interfaces, then the memory region is never released by netmap. After closing both file descriptors the memory remains in use.

With the extra debugging info enabled by NM_DEBUG_MEM_PUTGET, I could see that nmd->refcount was incremented twice after opening both interfaces, but after closing both file descriptors, nmd->refcount was decremented only once. Only when the last file descriptor using that memory region was released, the reference counter was decremented.

I made a fix for this issue that works for me. I'm not sure if this is the right/best way to fix the problem, perhaps I don't understand the intention of the code well enough. But anyway, it is important that the calls to netmap_mem_get() and netmap_mem_put() are symmetrical.

Thanks in advance for reviewing this change.
