### PR TITLE
linux: FOLL_SPLIT is removed in 5.15.

### DIFF
--- a/LINUX/bsd_glue.h
+++ b/LINUX/bsd_glue.h
@@ -148,6 +148,9 @@ struct net_device_ops {
 			NM_SET_PAGE_COUNT(&(page)[i_], 1);\
 	} while (0)
 #endif /* HAVE_SPLIT_PAGE */
+#ifndef NETMAP_LINUX_HAVE_FOLL_SPLIT
+#define FOLL_SPLIT	FOLL_SPLIT_PMD
+#endif
 
 #if !defined(NETMAP_LINUX_HAVE_NNITD) && !defined(netdev_notifier_info_to_dev)
 #define netdev_notifier_info_to_dev(ptr)	(ptr)

--- a/LINUX/configure
+++ b/LINUX/configure
@@ -1731,6 +1731,15 @@ EOF
 	}
 EOF
 
+  add_test 'have FOLL_SPLIT' <<EOF
+	#include <linux/mm.h>
+
+	int
+	dummy(void) {
+		return FOLL_SPLIT;
+	}
+EOF
+
 # check for page_to_virt
   add_test 'have PAGE_TO_VIRT' <<EOF
   	#include <linux/mm.h>


### PR DESCRIPTION
https://patchwork.kernel.org/project/linux-mm/patch/20210430055556.xcmsU3Fo2%25akpm@linux-foundation.org/