### PR TITLE
Fix variable 'err' usage and compilation

### DIFF
--- a/apps/nmreplay/nmreplay.c
+++ b/apps/nmreplay/nmreplay.c
@@ -1273,7 +1273,7 @@ main(int argc, char **argv)
 	D("exiting on abort");
 	sleep(1);
 
-	return (0);
+	return (err);
 }
 
 /* conversion factor for numbers.


### PR DESCRIPTION
Fix compilation and correct usage of the err variable:

nmreplay.c:1105:13: error: variable 'err' set but not used [-Werror,-Wunused-but-set-variable]
        int ch, i, err=0;