### PR TITLE
linux/veth: fix kernel oops

### DIFF
--- a/LINUX/veth_netmap.h
+++ b/LINUX/veth_netmap.h
@@ -156,11 +156,15 @@ veth_netmap_reg(struct netmap_adapter *na, int onoff)
 		return 0;
 	}
 	if (onoff) {
-		vna->peer->peer_ref = 0;
-		netmap_adapter_put(na);
+		if (vna->peer->peer_ref) {
+			vna->peer->peer_ref = 0;
+			netmap_adapter_put(na);
+		}
 	} else {
-		netmap_adapter_get(na);
-		vna->peer->peer_ref = 1;
+		if (!vna->peer->peer_ref) {
+			netmap_adapter_get(na);
+			vna->peer->peer_ref = 1;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Check peer_ref before incrementing/decrementig na_refcount.
Oops can be reproduced with pkt-gen:
ip l a dev vetha type veth peer name vethb
./build-apps/pkt-gen/pkt-gen -f rx -i vetha &
sleep 1
./build-apps/pkt-gen/pkt-gen -f rx -i vethb^ &
sleep 1
./build-apps/pkt-gen/pkt-gen -f rx -i vethb-0 &
sleep 1
killall pkt-gen
./build-apps/pkt-gen/pkt-gen -f rx -i vetha
There is two calls of nm_register for interface vethb.
First one on creating host-ring vethb^ and the second on vethb-0.
If we do not check peer_ref then we would dereferencing peer twice.