### PR TITLE
Swap the src and dst IPv4 address in the pong msg

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -1547,6 +1547,11 @@ pong_body(void *data)
 				dpkt[3] = spkt[0];
 				dpkt[4] = spkt[1];
 				dpkt[5] = spkt[2];
+				/* swap source and destination IPv4 */
+				dpkt[13] = spkt[15];
+				dpkt[14] = spkt[16];
+				dpkt[15] = spkt[13];
+				dpkt[16] = spkt[14];
 				txring->slot[txhead].len = slot->len;
 				txhead = nm_ring_next(txring, txhead);
 				txavail--;

--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -1557,7 +1557,7 @@ pong_body(void *data)
 				dpkt[4] = spkt[1];
 				dpkt[5] = spkt[2];
 				/* swap source and destination IPv4 */
-				if (ntohs(spkt[6]) & ETHERTYPE_IP) {
+				if (spkt[6] == htons(ETHERTYPE_IP)) {
 					dpkt[13] = spkt[15];
 					dpkt[14] = spkt[16];
 					dpkt[15] = spkt[13];

--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -1322,6 +1322,10 @@ ping_body(void *data)
 		return NULL;
 	}
 
+	if (targ->g->af == AF_INET6) {
+		D("Warning: ping-pong with IPv6 not supported");
+	}
+
 	bzero(&buckets, sizeof(buckets));
 	clock_gettime(CLOCK_REALTIME_PRECISE, &last_print);
 	now = last_print;
@@ -1504,6 +1508,11 @@ pong_body(void *data)
 	if (n > 0)
 		D("understood ponger %llu but don't know how to do it",
 			(unsigned long long)n);
+
+	if (targ->g->af == AF_INET6) {
+		D("Warning: ping-pong with IPv6 not supported");
+	}
+
 	while (!targ->cancel && (n == 0 || sent < n)) {
 		uint32_t txhead, txavail;
 //#define BUSYWAIT
@@ -1548,11 +1557,14 @@ pong_body(void *data)
 				dpkt[4] = spkt[1];
 				dpkt[5] = spkt[2];
 				/* swap source and destination IPv4 */
-				dpkt[13] = spkt[15];
-				dpkt[14] = spkt[16];
-				dpkt[15] = spkt[13];
-				dpkt[16] = spkt[14];
+				if (ntohs(spkt[6]) & ETHERTYPE_IP) {
+					dpkt[13] = spkt[15];
+					dpkt[14] = spkt[16];
+					dpkt[15] = spkt[13];
+					dpkt[16] = spkt[14];
+				}
 				txring->slot[txhead].len = slot->len;
+				//dump_payload(dst, slot->len, txring, txhead);
 				txhead = nm_ring_next(txring, txhead);
 				txavail--;
 				sent++;


### PR DESCRIPTION
The current ```pkt-gen``` tool only flips the source and destination MAC address without flipping the IP addresses. This becomes problematic when working with links with NAT or hops in between. The PR flips the IPv4 address in a pong response.