### PR TITLE
linux/ice: add patch for ice 1.9.7

### DIFF
--- a/LINUX/default-config.mak.in_
+++ b/LINUX/default-config.mak.in_
@@ -92,7 +92,7 @@ e1000e@prepare := $(if $(filter $(e1000e@v),3.8.4 3.8.7),@BUILDDIR@/intel-fix.sh
 ixgbevf@prepare := $(if $(filter $(ixgbevf@v),4.7.1 4.8.1 4.9.3 4.10.2 4.11.1 4.12.4 4.13.3 4.14.5 4.15.1),@BUILDDIR@/intel-fix.sh ixgbevf,)
 ixgbe@prepare := $(if $(filter $(ixgbe@v),5.8.1 5.9.4 5.10.2 5.11.3 5.12.5 5.13.4),@BUILDDIR@/intel-fix.sh ixgbe,)
 i40e@prepare := $(if $(filter $(i40e@v),2.12.6 2.14.13 2.15.9 2.16.11 2.17.4 2.17.15 2.18.9 2.19.3),@BUILDDIR@/intel-fix.sh i40e,)
-ice@prepare := $(if $(filter $(ice@v),1.7.16 1.8.8 18.9),@BUILDDIR@/intel-fix.sh ice,)
+ice@prepare := $(if $(filter $(ice@v),1.7.16 1.8.8 1.8.9 1.9.7),@BUILDDIR@/intel-fix.sh ice,)
 
 # some additional, driver-specific configuration
 stmmac@conf := CONFIG_STMMAC_ETH

--- a/LINUX/final-patches/intel--ice--1.9.7
+++ b/LINUX/final-patches/intel--ice--1.9.7
@@ -1,0 +1,247 @@
+From: Przemek Kitszel <przemyslaw.kitszel@intel.com>
+Date: Fri, 8 Jul 2022 17:38:11 +0200
+Subject: [PATCH] linux/ice: add patch for ice 1.9.7
+
+Most of the code is originating from [1] by Giuseppe Lettieri.
+
+Source patch [1] was for 1.8.9, last updated in commit e827ea6965d5c47b1:
+"(linux/ice: fix hooks and callbacks)"
+[1] https://github.com/luigirizzo/netmap/commit/e827ea6965d5c47b13eed24cd7dca2798b40fae9
+Style changes applied.
+
+Adjusted for changes in ice 1.9
+
+Signed-off-by: Przemek Kitszel <przemyslaw.kitszel@intel.com>
+---
+ ice/Makefile   | 34 +++++++++++++++++-----------------
+ ice/ice_base.c | 18 ++++++++++++++++++
+ ice/ice_main.c | 16 +++++++++++++++-
+ ice/ice_txrx.c | 19 +++++++++++++++++++
+ 4 files changed, 69 insertions(+), 18 deletions(-)
+
+diff --git a/ice/Makefile b/ice/Makefile
+index d94e327ac524..a27bf9db0eac 100644
+--- a/ice/Makefile
++++ b/ice/Makefile
+@@ -26,9 +26,9 @@ ifneq ($(KERNELRELEASE),)
+ ccflags-y += -I$(src)
+ subdir-ccflags-y += -I$(src)
+ 
+-obj-m += ice.o
++obj-m += ice$(NETMAP_DRIVER_SUFFIX).o
+ 
+-ice-y := ice_main.o	\
++ice$(NETMAP_DRIVER_SUFFIX)-y := ice_main.o	\
+ 	 ice_controlq.o	\
+ 	 ice_common.o	\
+ 	 ice_nvm.o	\
+@@ -58,12 +58,12 @@ ice-y := ice_main.o	\
+ 	 ice_fwlog.o		\
+ 	 ice_ieps.o		\
+ 	 ice_ethtool.o
+-ice-$(CONFIG_NET_DEVLINK:m=y) += ice_devlink.o ice_fw_update.o
+-ice-$(CONFIG_NET_DEVLINK:m=y) += ice_eswitch.o ice_repr.o
+-ice-y += ice_idc.o
+-ice-$(CONFIG_DEBUG_FS) += ice_debugfs.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_NET_DEVLINK:m=y) += ice_devlink.o ice_fw_update.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_NET_DEVLINK:m=y) += ice_eswitch.o ice_repr.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += ice_idc.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_DEBUG_FS) += ice_debugfs.o
+ 
+-ice-$(CONFIG_PCI_IOV) +=		\
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_IOV) +=		\
+ 	ice_dcf.o			\
+ 	ice_sriov.o			\
+ 	ice_vf_mbx.o			\
+@@ -75,20 +75,20 @@ ice-$(CONFIG_PCI_IOV) +=		\
+ 	ice_vf_lib.o
+ 
+ ifneq (${ENABLE_SIOV_SUPPORT},)
+-ice-$(CONFIG_VFIO_MDEV:m=y) += ice_vdcm.o ice_siov.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_VFIO_MDEV:m=y) += ice_vdcm.o ice_siov.o
+ endif
+-ice-$(CONFIG_PTP_1588_CLOCK:m=y) += ice_ptp.o ice_ptp_hw.o
+-ice-$(CONFIG_DCB) += ice_dcb.o ice_dcb_nl.o ice_dcb_lib.o
+-ice-$(CONFIG_RFS_ACCEL) += ice_arfs.o
+-ice-$(CONFIG_XDP_SOCKETS) += ice_xsk.o
+-ice-y += kcompat.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PTP_1588_CLOCK:m=y) += ice_ptp.o ice_ptp_hw.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_DCB) += ice_dcb.o ice_dcb_nl.o ice_dcb_lib.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_RFS_ACCEL) += ice_arfs.o
++ice$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_XDP_SOCKETS) += ice_xsk.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += kcompat.o
+ # Use kcompat pldmfw.c if kernel does not provide CONFIG_PLDMFW
+ ifndef CONFIG_PLDMFW
+-ice-y += kcompat_pldmfw.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += kcompat_pldmfw.o
+ endif
+ # Use kcompat DIMLIB if kernel doesn't provide it
+ ifndef CONFIG_DIMLIB
+-ice-y += kcompat_dim.o kcompat_net_dim.o
++ice$(NETMAP_DRIVER_SUFFIX)-y += kcompat_dim.o kcompat_net_dim.o
+ endif
+ 
+ ifeq (${NEED_AUX_BUS},2)
+@@ -98,7 +98,7 @@ endif
+ else	# ifneq($(KERNELRELEASE),)
+ # normal makefile
+ 
+-DRIVER := ice
++DRIVER := ice$(NETMAP_DRIVER_SUFFIX)
+ 
+ COMMON_MK ?= $(wildcard common.mk)
+ ifeq (${COMMON_MK},)
+@@ -131,7 +131,7 @@ endif
+ 
+ all:
+ 	+$(call kernelbuild,modules)
+-	@gzip -c ../${DRIVER}.${MANSECTION} > ${DRIVER}.${MANSECTION}.gz
++#	@gzip -c ../${DRIVER}.${MANSECTION} > ${DRIVER}.${MANSECTION}.gz
+ ifneq ($(wildcard lttng),)
+ 	$(MAKE) -C lttng
+ endif
+diff --git a/ice/ice_base.c b/ice/ice_base.c
+index b43752ea2efd..b198554e4759 100644
+--- a/ice/ice_base.c
++++ b/ice/ice_base.c
+@@ -6,6 +6,11 @@
+ #include "ice_dcb_lib.h"
+ #include "ice_sriov.h"
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++#define NETMAP_ICE_BASE
++#include <ice_netmap_linux.h>
++#endif
++
+ /**
+  * __ice_vsi_get_qs_contig - Assign a contiguous chunk of queues to VSI
+  * @qs_cfg: gathered variables needed for PF->VSI queues assignment
+@@ -461,6 +466,10 @@ static int ice_setup_rx_ctx(struct ice_ring *ring)
+ 	/* Rx queue threshold in units of 64 */
+ 	rlan_ctx.lrxqthresh = 1;
+ 
++#ifdef DEV_NETMAP
++	ice_netmap_preconfigure_rx_ring(ring, &rlan_ctx);
++#endif /* DEV_NETMAP */
++
+ 	/* Enable Flexible Descriptors in the queue context which
+ 	 * allows this driver to select a specific receive descriptor format
+ 	 * increasing context priority to pick up profile ID; default is 0x01;
+@@ -618,6 +627,11 @@ int ice_vsi_cfg_rxq(struct ice_ring *ring)
+ 	}
+ #endif /* HAVE_AF_XDP_ZC_SUPPORT */
+ 
++#ifdef DEV_NETMAP
++	if (ice_netmap_configure_rx_ring(ring))
++		return 0;
++#endif /* DEV_NETMAP */
++
+ 	ice_alloc_rx_bufs(ring, num_bufs);
+ 
+ 	return 0;
+@@ -890,6 +904,10 @@ ice_vsi_cfg_txq(struct ice_vsi *vsi, struct ice_ring *tx_ring,
+ 	if (pf_q == le16_to_cpu(txq->txq_id))
+ 		tx_ring->txq_teid = le32_to_cpu(txq->q_teid);
+ 
++#ifdef DEV_NETMAP
++	ice_netmap_configure_tx_ring(tx_ring);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ }
+ 
+diff --git a/ice/ice_main.c b/ice/ice_main.c
+index 88d90ab52672..43e43cf85890 100644
+--- a/ice/ice_main.c
++++ b/ice/ice_main.c
+@@ -29,7 +29,7 @@
+ #define DRV_VERSION_MINOR 9
+ #define DRV_VERSION_BUILD 7
+ 
+-#define DRV_VERSION	"1.9.7"
++#define DRV_VERSION	"1.9.7_netmap"
+ #define DRV_SUMMARY	"Intel(R) Ethernet Connection E800 Series Linux Driver"
+ #ifdef ICE_ADD_PROBES
+ #define DRV_VERSION_EXTRA "_probes"
+@@ -104,6 +104,11 @@ static unsigned long fwlog_events; /* no enabled events by default */
+ module_param(fwlog_events, ulong, 0644);
+ MODULE_PARM_DESC(fwlog_events, "FW events to log (32-bit mask)\n");
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++#define NETMAP_ICE_LIB
++#include <ice_netmap_linux.h>
++#endif
++
+ /**
+  * ice_hw_to_dev - Get device pointer from the hardware structure
+  * @hw: pointer to the device HW structure
+@@ -6336,6 +6341,10 @@ probe_done:
+ #ifdef HAVE_DEVLINK_NOTIFY_REGISTER
+ 	ice_devlink_register(pf);
+ #endif /* HAVE_DEVLINK_NOTIFY_REGISTER */
++
++#ifdef DEV_NETMAP
++	ice_netmap_attach(pf);
++#endif
+ 	return 0;
+ 
+ 	/* Unwind non-managed device resources, etc. if something failed */
+@@ -6459,6 +6468,11 @@ static void ice_remove(struct pci_dev *pdev)
+ 		return;
+ 
+ 	hw = &pf->hw;
++
++#ifdef DEV_NETMAP
++	ice_netmap_detach(pf);
++#endif /* DEV_NETMAP */
++
+ 	/* ICE_PREPPED_RECOVERY_MODE is set when the up and running
+ 	 * driver transitions to recovery mode. If this is not set
+ 	 * it means that the driver went into recovery mode on load.
+diff --git a/ice/ice_txrx.c b/ice/ice_txrx.c
+index a094aec61fe2..84c75a96d71d 100644
+--- a/ice/ice_txrx.c
++++ b/ice/ice_txrx.c
+@@ -30,6 +30,10 @@
+ #define FDIR_DESC_RXDID 0x40
+ #define ICE_FDIR_CLEAN_DELAY 10
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++#include <ice_netmap_linux.h>
++#endif
++
+ /**
+  * ice_prgm_fdir_fltr - Program a Flow Director filter
+  * @vsi: VSI to send dummy packet
+@@ -228,6 +232,12 @@ static bool ice_clean_tx_irq(struct ice_ring *tx_ring, int napi_budget)
+ 	struct ice_tx_desc *tx_desc;
+ 	struct ice_tx_buf *tx_buf;
+ 
++#ifdef DEV_NETMAP
++	if (tx_ring->netdev &&
++	    netmap_tx_irq(tx_ring->netdev, tx_ring->q_index) != NM_IRQ_PASS)
++		return true;
++#endif /* DEV_NETMAP */
++
+ 	/* get the bql data ready */
+ #ifdef HAVE_XDP_SUPPORT
+ 	if (!ice_ring_is_xdp(tx_ring))
+@@ -1472,6 +1482,15 @@ int ice_clean_rx_irq(struct ice_ring *rx_ring, int budget)
+ 	struct xdp_buff xdp;
+ 	bool failure;
+ 
++#ifdef DEV_NETMAP
++	if (rx_ring->netdev) {
++		int dummy, nm_irq;
++		nm_irq = netmap_rx_irq(rx_ring->netdev, rx_ring->q_index, &dummy);
++		if (nm_irq != NM_IRQ_PASS)
++			return 1;
++	}
++#endif /* DEV_NETMAP */
++
+ #ifdef HAVE_XDP_SUPPORT
+ #ifdef HAVE_XDP_BUFF_RXQ
+ 	xdp.rxq = &rx_ring->xdp_rxq;
+-- 
+2.31.1
+


### PR DESCRIPTION
Most of the code is originating from [1] by Giuseppe Lettieri.

Source patch [1] was for 1.8.9, last updated in commit e827ea6965d5c47b1:
"(linux/ice: fix hooks and callbacks)"
[1] https://github.com/luigirizzo/netmap/commit/e827ea6965d5c47b13eed24cd7dca2798b40fae9
Style changes applied.

Adjusted for changes in ice 1.9

Signed-off-by: Przemek Kitszel <przemyslaw.kitszel@intel.com>