### PR TITLE
lb/pkt_hash: Fix ip_hl check.

### DIFF
--- a/apps/lb/pkt_hash.c
+++ b/apps/lb/pkt_hash.c
@@ -150,7 +150,7 @@ decode_ip_n_hash(const struct ip *iph, uint8_t hash_split, uint8_t seed)
 {
 	uint32_t rc = 0;
 
-	if (iph->ip_hl < 5 || iph->ip_hl * 4 > iph->ip_len) {
+	if (iph->ip_hl < 5 || (iph->ip_hl<<2) > ntohs(iph->ip_len)) {
 		rc = 0;
 	} else if (hash_split == 2) {
 		rc = sym_hash_fn(ntohl(iph->ip_src.s_addr),


### PR DESCRIPTION
As far as I can tell the missing `ntohs()` can lead to the hash being erroneously set to zero, which could break load balancing.