### PR TITLE
pkt-gen.c: fix ifname before comparing in source_hwaddr()

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -684,6 +684,10 @@ source_hwaddr(const char *ifname, char *buf)
 		return (-1);
 	}
 
+	/* remove 'netmap:' prefix before comparing interfaces */
+	if (!strncmp(ifname, "netmap:", 7))
+		ifname = &ifname[7];
+
 	for (ifap = ifaphead; ifap; ifap = ifap->ifa_next) {
 		struct sockaddr_dl *sdl =
 			(struct sockaddr_dl *)ifap->ifa_addr;


### PR DESCRIPTION
While testing with pkt-gen on FreeBSD-12.3, I observed that the source MAC address was always 00:00:00:00:00:00. I looked at the code and saw that `source_hwaddr()` should retrieve the system interface MAC address and set it as the source.

After some debugging, I discovered that the argument parsing code in `main()` was prefixing the interface with "netmap:" if no type was given. (At the same time, it removed any "tap:" or "pcap:" prefixes.) Therefore, when it came time to compare the interface name to the system interfaces, there was never a match for netmap devices.

My proposed fix is to check if the interface begins with "netmap:" in `source_hwaddr()` and if so, skip over that prefix. In my testing, the fix correctly obtains the hardware MAC address and uses it as the source MAC.