### PR TITLE
pkt-gen: fix sending uninitialized slots when using multiple tx rings

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -1602,7 +1602,7 @@ sender_body(void *data)
 	uint64_t n = targ->g->npackets / targ->g->nthreads;
 	uint64_t sent = 0;
 	uint64_t event = 0;
-	int options = targ->g->options | OPT_COPY;
+	int options = targ->g->options;
 	struct timespec nexttime = { 0, 0}; // XXX silence compiler
 	int rate_limit = targ->g->tx_rate;
 	struct pkt *pkt = &targ->pkt;
@@ -1676,6 +1676,19 @@ sender_body(void *data)
 			targ->frags++;
 	}
 	D("frags %u frag_size %u", targ->frags, targ->frag_size);
+
+	/* mark all slots of all rings as changed so initial copy will be done */
+	for (i = targ->nmd->first_tx_ring; i <= targ->nmd->last_tx_ring; i++) {
+		uint32_t j;
+		struct netmap_slot *slot;
+
+		txring = NETMAP_TXRING(nifp, i);
+		for (j = 0; j < txring->num_slots; j++) {
+			slot = &txring->slot[j];
+			slot->flags = NS_BUF_CHANGED;
+		}
+	}
+
 	while (!targ->cancel && (n == 0 || sent < n)) {
 		int rv;
 
@@ -1712,10 +1725,6 @@ sender_body(void *data)
 		/*
 		 * scan our queues and send on those with room
 		 */
-		if (options & OPT_COPY && sent > 100000 && !(targ->g->options & OPT_COPY) ) {
-			D("drop copy");
-			options &= ~OPT_COPY;
-		}
 		for (i = targ->nmd->first_tx_ring; i <= targ->nmd->last_tx_ring; i++) {
 			int m;
 			uint64_t limit = rate_limit ?  tosend : targ->g->burst;


### PR DESCRIPTION
Hello,

I observed sporadic rx-err packets when using pkt-gen between two FreeBSD systems. Sporadic meaning it didn't happen every run but if it did happen it continued every second. Using the OPT_DUMP option to log all outgoing packets, I saw there was one packet each burst that was all zeros.

Some code reading brought me to the "drop copy" log message. sender_body() adds OPT_COPY to the options which forces a copy of the packet data into the ring slot. After 100,000 packets the function removes the OPT_COPY option. I suspect the reasoning was by that point every slot has a copy of the packet and there is a significant performance improvement by not copying the packet every time.

The problem occurs with multiple transmit rings. The code always starts with the first ring and moves on if a ring fills up while sending the burst. If the first 100,000 packets can be sent using only ring 0, then none of the other rings will be initialized. Should a slowdown somewhere eventually cause ring 0 to fill up, the code will start sending slots from ring 1 which never got a copy of the packet.

I'm written a patch to set the NS_BUF_CHANGED flag on every slot of every ring early in sender_body(). Later in send_packets(), a copy is forced if the flag is set and then the flag is cleared. This ensures that every slot receives a copy of the packet before being used. It also provides the best performance as the copy is only done once.