### PR TITLE
Fix compilation on some 32-bit platforms

### DIFF
--- a/apps/pkt-gen/pkt-gen.c
+++ b/apps/pkt-gen/pkt-gen.c
@@ -3284,8 +3284,8 @@ out:
 		g.tx_period.tv_nsec = g.tx_period.tv_nsec % 1000000000;
 	}
 	if (g.td_type == TD_TYPE_SENDER)
-	    D("Sending %d packets every  %ld.%09ld s",
-			g.burst, g.tx_period.tv_sec, g.tx_period.tv_nsec);
+	    D("Sending %d packets every  %jd.%09ld s",
+			g.burst, (intmax_t)g.tx_period.tv_sec, g.tx_period.tv_nsec);
 	/* Install ^C handler. */
 	global_nthreads = g.nthreads;
 	sigemptyset(&ss);


### PR DESCRIPTION
The type of `tv_sec` is `time_t`, which is 32-bit on some platforms. The type of `tv_nsec` is `long` (`long long` only since C23).

When building the port net/pkt-gen without this patch, a package fallout occurs.

Cast to an `intmax_t` to avoid the warning/error, given `-Werror` (NB: The original patch in the net/pkt-gen port used a `long long`, we opted for an `intmax_t` instead).

See the aftermath of bug report #270440 for further details.