### PR TITLE
apps: Import man page changes, mostly from FreeBSD

### DIFF
--- a/apps/bridge/bridge.8
+++ b/apps/bridge/bridge.8
@@ -23,7 +23,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd October 23, 2018
+.Dd November 21, 2020
 .Dt BRIDGE 8
 .Os
 .Sh NAME
@@ -49,6 +49,20 @@ forwards packets without copying the packets payload (zero-copy mode), unless
 explicitly prevented by the
 .Fl c
 flag.
+.Pp
+When bridging two physical ports, it is necessary that both NICS are in
+promiscuous mode, otherwise unicast traffic directed to other hosts will
+be dropped by the hardware, and bridging will not work.
+.Pp
+When bridging the hardware rings of a physical port with the corresponding
+host rings, it is necessary to turn off the offloads, because netmap does
+not prepare the NIC rings with offload information.
+Example:
+.Bd -literal -offset indent
+ifconfig em0 -rxcsum -txcsum -tso4 -tso6 -lro
+.Ed
+.Pp
+Available options:
 .Bl -tag -width Ds
 .It Fl i Ar port
 Name of the netmap port.
@@ -71,6 +85,7 @@ Disable zero-copy mode.
 .El
 .Sh SEE ALSO
 .Xr netmap 4 ,
+.Xr lb 8 ,
 .Xr pkt-gen 8
 .Sh AUTHORS
 .An -nosplit

--- a/apps/nmreplay/nmreplay.8
+++ b/apps/nmreplay/nmreplay.8
@@ -24,7 +24,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd February 16, 2016
+.Dd December 21, 2018
 .Dt NMREPLAY 8
 .Os
 .Sh NAME
@@ -43,6 +43,8 @@
 .Op Fl w Ar wait-link
 .Op Fl v
 .Op Fl C Ar cpu-placement
+.El
+.Ek
 .Sh DESCRIPTION
 .Nm
 works like
@@ -62,7 +64,8 @@ Command line options are as follows
 .It Fl f Ar pcap-file
 Name of the pcap file to replay.
 .It Fl i Ar interface
-Name of the netmap interface to use as output. See
+Name of the netmap interface to use as output.
+See
 .Xr netmap 4
 for interface name format.
 .It Fl v
@@ -73,7 +76,7 @@ Maximum batch size to use during transmissions.
 normally transmits packets one at a time, but it may use
 larger batches, up to the value specified with this option,
 when running at high rates.
-.It Fl B Ar bps | Cm constant, Ns Ar bps | Cm ether, Ns Ar bps | Cm real Ns Op , Ns Ar speedup
+.It Fl B Ar bps | Cm constant , Ns Ar bps | Cm ether , Ns Ar bps | Cm real Ns Op , Ns Ar speedup
 Bandwidth to be used for transmission.
 .Ar bps
 is a floating point number optionally follow by a character
@@ -87,11 +90,12 @@ indicates that the ethernet framing (160 bits) and CRC (32 bits)
 will be included in the computation of the packet size.
 .Cm real
 means transmission will occur according to the timestamps
-recorded in the trace. The optional
+recorded in the trace.
+The optional
 .Ar speedup
 multiplier (defaults to 1) indicates how much faster
 or slower than real time the trace should be replayed.
-.It Fl D Ar dt | Cm constant, Ns Ar dt | Cm uniform, Ns Ar dmin,dmax | Cm exp, Ar dmin,davg
+.It Fl D Ar dt | Cm constant , Ns Ar dt | Cm uniform , Ns Ar dmin,dmax | Cm exp , Ar dmin,davg
 Adds additional delay to the packet transmission, whose distribution
 can be constant, uniform or exponential.
 .Ar dt, dmin, dmax, avt
@@ -100,7 +104,7 @@ by a character (s, m, u, n) to indicate seconds, milliseconds,
 microseconds, nanoseconds.
 The delay is added to the transmit time and adjusted so that there is
 never packet reordering.
-.It Fl L Ar x | Cm plr, Ns Ar x | Cm ber, Ns Ar x
+.It Fl L Ar x | Cm plr , Ns Ar x | Cm ber , Ns Ar x
 Simulates packet or bit errors, causing offending packets to be dropped.
 .Ar x
 is a floating point number indicating the packet or bit error rate.
@@ -115,14 +119,7 @@ creates an in-memory schedule with all packets to be transmitted,
 and then launches a separate thread to take care of transmissions
 while the main thread reports statistics every second.
 .Sh SEE ALSO
-.Pa http://info.iet.unipi.it/~luigi/netmap/
-.Pp
-Luigi Rizzo, Revisiting network I/O APIs: the netmap framework,
-Communications of the ACM, 55 (3), pp.45-51, March 2012
-.Pp
-Luigi Rizzo, Giuseppe Lettieri,
-VALE, a switched ethernet for virtual machines,
-ACM CoNEXT'12, December 2012, Nice
+.Xr netmap 4
 .Sh AUTHORS
 .An -nosplit
 .Nm

--- a/apps/pkt-gen/pkt-gen.8
+++ b/apps/pkt-gen/pkt-gen.8
@@ -25,7 +25,7 @@
 .\"
 .\" $FreeBSD$
 .\"
-.Dd October 25, 2018
+.Dd April 21, 2023
 .Dt PKT-GEN 8
 .Os
 .Sh NAME
@@ -84,28 +84,28 @@ library function, as documented in
 The function to be executed by
 .Nm .
 Specify
-.Ar tx
+.Cm tx
 for transmission,
-.Ar rx
+.Cm rx
 for reception,
-.Ar ping
+.Cm ping
 for client-side ping-pong operation, and
-.Ar pong
+.Cm pong
 for server-side ping-pong operation.
 .It Fl n Ar count
 Number of iterations of the
 .Nm
 function (with 0 meaning infinite).
 In case of
-.Ar tx
+.Cm tx
 or
-.Ar rx ,
+.Cm rx ,
 .Ar count
 is the number of packets to receive or transmit.
 In case of
-.Ar ping
+.Cm ping
 or
-.Ar pong ,
+.Cm pong ,
 .Ar count
 is the number of ping-pong transactions.
 .It Fl l Ar pkt_size
@@ -144,9 +144,9 @@ to handle all the netmap rings.
 If
 .Ar threads
 is larger than one, each thread handles a single TX ring (in
-.Ar tx
+.Cm tx
 mode), a single RX ring (in
-.Ar rx
+.Cm rx
 mode), or a TX/RX ring pair.
 The number of
 .Ar threads
@@ -175,7 +175,8 @@ so this option should be used unless your intention is to saturate the link.
 .It Fl X
 Dump payload of each packet transmitted or received.
 .It Fl H Ar len
-Add empty virtio-net-header with size 'len'.
+Add empty virtio-net-header with size
+.Ar len .
 Valid sizes are 0, 10 and 12.
 This option is only used with Virtual Machine technologies that use virtio
 as a network interface.
@@ -218,7 +219,7 @@ examined.
 Increase the verbosity level.
 .It Fl r
 In
-.Ar tx
+.Cm tx
 mode, do not initialize packets, but send whatever the content of
 the uninitialized netmap buffers is (rubbish mode).
 .It Fl A
@@ -227,13 +228,13 @@ transmit or receive rate.
 .It Fl B
 Take Ethernet framing and CRC into account when computing the average bps.
 This adds 4 bytes of CRC and 20 bytes of framing to each packet.
-.It Fl C Ar tx_slots[,rx_slots[,tx_rings[,rx_rings]]]
+.It Fl C Ar tx_slots Ns Oo Cm \&, Ns Ar rx_slots Ns Oo Cm \&, Ns Ar tx_rings Ns Oo Cm \&, Ns Ar rx_rings Oc Oc Oc
 Configuration in terms of number of rings and slots to be used when
 opening the netmap port.
 Such configuration has an effect on software ports
 created on the fly, such as VALE ports and netmap pipes.
 The configuration may consist of 1 to 4 numbers separated by commas:
-.Ar tx_slots , rx_slots , tx_rings , rx_rings .
+.Dq tx_slots,rx_slots,tx_rings,rx_rings .
 Missing numbers or zeroes stand for default values.
 As an additional convenience, if exactly one number is specified,
 then this is assigned to both
@@ -278,17 +279,18 @@ Capture and count all packets arriving on the operating system's cxl0
 interface.
 Using this will block packets from reaching the operating
 system's network stack.
-.Pp
-.Nm
--i cxl0 -f rx
+.Bd -literal -offset indent
+pkt-gen -i cxl0 -f rx
+.Ed
 .Pp
 Send a stream of fake DNS packets between two hosts with a packet
 length of 128 bytes.
 You must set the destination MAC address for
 packets to be received by the target host.
-.Pp
-.Nm
--i netmap:ncxl0 -f tx -s 172.16.0.1:53 -d 172.16.1.3:53 -D 00:07:43:29:2a:e0
+.Bd -literal -offset indent
+pkt-gen -i netmap:ncxl0 -f tx -s 172.16.0.1:53 -d 172.16.1.3:53 \e
+-D 00:07:43:29:2a:e0
+.Ed
 .Sh SEE ALSO
 .Xr netmap 4 ,
 .Xr bridge 8


### PR DESCRIPTION
For bridge.8 and nmreplay.8, sync with FreeBSD.

For pkt-gen.8:
Chiefly, change .Ar (argument) macros with .Cm (command modifier).
Per mdoc(7):

> The arguments to the `Ar` macro are names and placeholders for command arguments; for fixed strings to be passed verbatim as arguments, use `Fl` or `Cm`.

Also, split a long command line.

For lb.8, leave as is, given FreeBSD renamed `vale-ctl` to `valectl`.