### PR TITLE
linux: Use correct define for vlan untagging.

### DIFF
--- a/LINUX/bsd_glue.h
+++ b/LINUX/bsd_glue.h
@@ -191,7 +191,7 @@ static inline int skb_checksum_start_offset(const struct sk_buff *skb) {
 #define page_to_virt(p) 		phys_to_virt(page_to_phys(p))
 #endif /* NETMAP_LINUX_HAVE_PAGE_TO_VIRT */
 
-#ifdef NETMAP_LINUX_HAVE_VLAN_UNTAG
+#ifdef NETMAP_LINUX_HAVE_SKB_VLAN_UNTAG
 #ifndef NETMAP_LINUX_HAVE_ETH_TYPE_VLAN
 static inline bool eth_type_vlan(__be16 ethertype)
 {
@@ -214,7 +214,7 @@ static inline struct sk_buff *__vlan_hwaccel_push_inside(struct sk_buff *skb)
 	return skb;
 }
 #endif /* NETMAP_LINUX_HAVE_VLAN_HWACCESS_PUSH_INSIDE */
-#endif /* NETMAP_LINUX_HAVE_VLAN_UNTAG */
+#endif /* NETMAP_LINUX_HAVE_SKB_VLAN_UNTAG */
 
 /*----------- end of LINUX_VERSION_CODE dependencies ----------*/
 

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -550,12 +550,12 @@ linux_generic_rx_handler_common(struct mbuf *m)
 	   can see it. */
 	skb_push(m, ETH_HLEN);
 
-#ifdef NETMAP_LINUX_HAVE_VLAN_UNTAG
+#ifdef NETMAP_LINUX_HAVE_SKB_VLAN_UNTAG
 	/* First VLAN tag has been already popped to skb metadata. */
 	if (skb_vlan_tag_present(m)) {
 		m = __vlan_hwaccel_push_inside(m);
 	}
-#endif /* NETMAP_LINUX_HAVE_VLAN_UNTAG */
+#endif /* NETMAP_LINUX_HAVE_SKB_VLAN_UNTAG */
 
 	/* Possibly steal the mbuf and notify the pollers for a new RX
 	 * packet. */
@@ -564,12 +564,12 @@ linux_generic_rx_handler_common(struct mbuf *m)
 		return NM_RX_HANDLER_STOLEN;
 	}
 
-#ifdef NETMAP_LINUX_HAVE_VLAN_UNTAG
+#ifdef NETMAP_LINUX_HAVE_SKB_VLAN_UNTAG
 	/* Untag once again if not stolen */
 	if (eth_type_vlan(m->protocol)) {
 		m = skb_vlan_untag(m);
 	}
-#endif /* NETMAP_LINUX_HAVE_VLAN_UNTAG */
+#endif /* NETMAP_LINUX_HAVE_SKB_VLAN_UNTAG */
 
 	skb_pull(m, ETH_HLEN);
 


### PR DESCRIPTION
Define being generated in LINUX/configure was slightly different to what was being used in code.