### PR TITLE
libnetmap: remove interface name validation

### DIFF
--- a/libnetmap/nmreq.c
+++ b/libnetmap/nmreq.c
@@ -156,11 +156,6 @@ nmreq_header_decode(const char **pifname, struct nmreq_header *h, struct nmctx *
 	for (pipesep = vpname; pipesep != scan && !index("{}", *pipesep); pipesep++)
 		;
 
-	if (!nm_is_identifier(vpname, pipesep)) {
-		nmctx_ferror(ctx, "%s: invalid port name '%.*s'", *pifname,
-				pipesep - vpname, vpname);
-		goto fail;
-	}
 	if (pipesep != scan) {
 		pipesep++;
 		if (*pipesep == '\0') {


### PR DESCRIPTION
When trying to use a VLAN device (e.g. "em0.123") with a dot
the library fails to parse the interface correctly. The former
pattern is much too restrictive given that almost all characters
can be coerced into a device name via ifconfig.

Remove the particularly restrictive validation.  Some characters
still cannot be used as an interface name as they are used as
delimiters in the syntax, but this allows to be able to use most
of them without an issue.

Note that the dotted VLAN naming is the default in FreeBSD now
and a patch was proposed here https://reviews.freebsd.org/D42485
as well.