### PR TITLE
linux: use net_if_rx_ni() in nm_os_send_up()

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -1305,6 +1305,16 @@ EOF
 	}
 EOF
 
+  # check for netif_rx_ni
+  add_test 'have NETIF_RX_NI' <<EOF
+	#include <linux/skbuff.h>
+
+	void dummy(struct sk_buff *skb)
+	{
+	    netif_rx_ni(skb);
+	}
+EOF
+
   # poll_table key field
   for k in _key key; do
 	add_test "define PWAIT_KEY $k" <<EOF

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -419,7 +419,12 @@ nm_os_send_up(struct ifnet *ifp, struct mbuf *m, struct mbuf *prev)
 	(void)ifp;
 	(void)prev;
 	m->priority = NM_MAGIC_PRIORITY_RX; /* do not reinject to netmap */
+#ifdef NETMAP_LINUX_HAVE_NETIF_RX_NI
+	netif_rx_ni(m);
+#else
 	netif_rx(m);
+#endif
+
 	return NULL;
 }
 


### PR DESCRIPTION
In older kernels net_if_rx() is to be used in interrupt context and netmap nm_os_send_up() is from process context. Thus using netif_rx_ni() is correct function variant in this case and using it prevents pending softirqs. In newer kernels netif_rx() can handle both contexts.