### PR TITLE
Fix Linux 6.5 support to avoid fortify panic

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -850,7 +850,7 @@ tc_configure(struct ifnet *ifp, const char *qdisc_name,
 	}
 
 	/* Push TCA_KIND attr. */
-	attr_kind = (struct nlattr *)(((void *)&nlreq.hdr) +
+	attr_kind = (struct nlattr *)(((void *)&nlreq) +
 				 NLMSG_ALIGN(nlreq.hdr.nlmsg_len));
 	attr_kind->nla_len = NLA_HDRLEN + strlen(qdisc_name) + 1;
 	attr_kind->nla_type = TCA_KIND;
@@ -860,7 +860,7 @@ tc_configure(struct ifnet *ifp, const char *qdisc_name,
 
 	if (limit > 0) {
 		/* Push TCA_OPTIONS attr. */
-		attr_opt = (struct nlattr *)(((void *)&nlreq.hdr) +
+		attr_opt = (struct nlattr *)(((void *)&nlreq) +
 					 NLMSG_ALIGN(nlreq.hdr.nlmsg_len));
 		attr_opt->nla_len = NLA_HDRLEN + sizeof(uint32_t);
 		attr_opt->nla_type = TCA_OPTIONS;
@@ -2207,7 +2207,6 @@ netmap_sink_init(void)
 	netdev->netdev_ops = &nm_sink_netdev_ops ;
 	strlcpy(netdev->name, "nmsink", sizeof(netdev->name));
 	netdev->features = NETIF_F_HIGHDMA;
-	strcpy(netdev->name, "nmsink%d");
 	err = register_netdev(netdev);
 	if (err) {
 		free_netdev(netdev);


### PR DESCRIPTION
Hello,

I believe this patch is a fix for issue #937 where fortify causes a panic in `tc_configure()` due to a "detected buffer overflow in strcpy". The `nlattr *` is set to `&nlreq.hdr` which has a fixed size causing the overflow. By setting `nlattr *` to `&nlreq` instead, the code sees the 100 byte `buf` space and does not panic. I tested this on kernel 6.5.0-21 and verified the `qdisc` name was properly set by using `tc`. With the fix I could run `pkt-gen` on multiple emulated netmap interfaces without seeing a panic.

While here I removed a duplicate `strcpy()` in `netmap_sink_init()`. I assumed "nmsink" is preferred to "nmsink%d".