### PR TITLE
Some mellanox housekeeping and a new driver version

### DIFF
--- a/LINUX/default-config.mak.in_
+++ b/LINUX/default-config.mak.in_
@@ -105,8 +105,8 @@ e1000e@fetch := test -e @SRCDIR@/ext-drivers/e1000e-$(e1000e@v).tar.gz || wget h
 endif
 
 define mellanox_driver
-$(1)@fetch	:= test -e @SRCDIR@/ext-drivers/mlnx-en-$(2)-ubuntu18.04-x86_64.tgz || wget http://content.mellanox.com/ofed/MLNX_EN-$(2)/mlnx-en-$(2)-ubuntu18.04-x86_64.tgz -P @SRCDIR@/ext-drivers
-$(1)@src	:= tar xf @SRCDIR@/ext-drivers/mlnx-en-$(2)-ubuntu18.04-x86_64.tgz && tar xf mlnx-en-$(2)-ubuntu18.04-x86_64/src/MLNX_EN_SRC-$(2).tgz && tar xf MLNX_EN_SRC-$(2)/SOURCES/mlnx-en_$($(1)@pv).orig.tar.gz && ln -s mlnx-en-$($(1)@pv) $(1)
+$(1)@fetch	:= test -e @SRCDIR@/ext-drivers/MLNX_EN_SRC-debian-$(2).tgz || wget https://content.mellanox.com/ofed/MLNX_EN-$(2)/MLNX_EN_SRC-debian-$(2).tgz -P @SRCDIR@/ext-drivers
+$(1)@src	:= tar xf @SRCDIR@/ext-drivers/MLNX_EN_SRC-debian-$(2).tgz&& tar xf MLNX_EN_SRC-$(2)/SOURCES/mlnx-en_$($(1)@pv).orig.tar.gz && ln -s mlnx-en-$($(1)@pv) $(1)
 $(1)@patch	:= patches/mellanox--$(1)--$($(1)@pv)
 $(1)@prepare	:= @SRCDIR@/mlx5-prepare.sh @KSRC@
 $(1)@build	:= make -C $(1) NETMAP_DRIVER_SUFFIX=@DRVSUFFIX@ EXTRA_CFLAGS="$$($(1)@cflags) $(EXTRA_CFLAGS)"

--- a/LINUX/default-config.mak.in_
+++ b/LINUX/default-config.mak.in_
@@ -116,7 +116,7 @@ $(1)@distclean  := rm -rf mlnx-en-$($(1)@pv) mlnx-en-$(2)
 $(1)@force	:= 1
 endef
 
-$(eval $(call default,mlx5,5.4-1.0.3.0))
+$(eval $(call default,mlx5,5.8-3.0.7.0))
 mlx5@pv		= $(firstword $(subst -, ,$(mlx5@v)))
 mlx5@conf	= CONFIG_MLX5_CORE_EN
 mlx5@cflags	= -Wframe-larger-than=2000

--- a/LINUX/dkms/dkms.conf
+++ b/LINUX/dkms/dkms.conf
@@ -50,3 +50,24 @@ DEST_MODULE_LOCATION[8]=/kernel/drivers/net/ethernet/intel/i40e/
 BUILT_MODULE_NAME[9]=vmxnet3
 BUILT_MODULE_LOCATION[9]=vmxnet3/
 DEST_MODULE_LOCATION[9]=/kernel/drivers/net/vmxnet3/
+
+# mlx5 driver
+BUILT_MODULE_NAME[10]=mlx5_core
+BUILT_MODULE_LOCATION[10]=mlx5/drivers/net/ethernet/mellanox/mlx5/core
+DEST_MODULE_LOCATION[10]=/kernel/drivers/net/ethernet/mellanox/mlx5/
+
+BUILT_MODULE_NAME[11]=mlxfw
+BUILT_MODULE_LOCATION[11]=mlx5/drivers/net/ethernet/mellanox/mlxfw/
+DEST_MODULE_LOCATION[11]=/kernel/drivers/net/ethernet/mellanox/mlx5/
+
+BUILT_MODULE_NAME[12]=mlx_compat
+BUILT_MODULE_LOCATION[12]=mlx5/compat/
+DEST_MODULE_LOCATION[12]=/kernel/drivers/net/ethernet/mellanox/mlx5/
+
+BUILT_MODULE_NAME[13]=auxiliary
+BUILT_MODULE_LOCATION[13]=mlx5/drivers/base/
+DEST_MODULE_LOCATION[13]=/kernel/drivers/net/ethernet/mellanox/mlx5/
+
+BUILT_MODULE_NAME[14]=mlxdevm
+BUILT_MODULE_LOCATION[14]=mlx5/net/mlxdevm/
+DEST_MODULE_LOCATION[14]=/kernel/drivers/net/ethernet/mellanox/mlx5/

--- a/LINUX/final-patches/mellanox--mlx5--5.3
+++ b/LINUX/final-patches/mellanox--mlx5--5.3
@@ -140,7 +140,7 @@ index a6dceb6..a3cb81d 100644
  
  	netdev_err(sq->netdev,
 diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
-index 47260b9..0c0e90a 100644
+index 47260b9..25857eb 100644
 --- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
 +++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
 @@ -84,8 +84,21 @@
@@ -165,18 +165,7 @@ index 47260b9..0c0e90a 100644
  	bool striding_rq_umr = MLX5_CAP_GEN(mdev, striding_rq) &&
  		MLX5_CAP_GEN(mdev, umr_ptr_rlky) &&
  		MLX5_CAP_ETH(mdev, reg_umr_sq);
-@@ -824,6 +837,10 @@ static int mlx5e_alloc_rq(struct mlx5e_channel *c,
- 		rq->dim_obj.dim.mode = DIM_CQ_PERIOD_MODE_START_FROM_EQE;
- 	}
- 
-+#ifdef DEV_NETMAP
-+	mlx5e_netmap_configure_rx_ring(rq, rq->ix);
-+#endif /* DEV_NETMAP */
-+
- 	return 0;
- 
- err_free_by_rq_type:
-@@ -1051,6 +1068,12 @@ int mlx5e_wait_for_min_rx_wqes(struct mlx5e_rq *rq, int wait_time)
+@@ -1051,6 +1064,12 @@ int mlx5e_wait_for_min_rx_wqes(struct mlx5e_rq *rq, int wait_time)
  {
  	unsigned long exp_time = jiffies + msecs_to_jiffies(wait_time);
  
@@ -189,7 +178,7 @@ index 47260b9..0c0e90a 100644
  	u16 min_wqes = mlx5_min_rx_wqes(rq->wq_type, mlx5e_rqwq_get_size(rq));
  
  	do {
-@@ -1115,6 +1138,10 @@ void mlx5e_free_rx_descs(struct mlx5e_rq *rq)
+@@ -1115,6 +1134,10 @@ void mlx5e_free_rx_descs(struct mlx5e_rq *rq)
  
  		while (!mlx5_wq_cyc_is_empty(wq)) {
  			wqe_ix = mlx5_wq_cyc_get_tail(wq);
@@ -200,6 +189,17 @@ index 47260b9..0c0e90a 100644
  			rq->dealloc_wqe(rq, wqe_ix);
  			mlx5_wq_cyc_pop(wq);
  		}
+@@ -1248,6 +1271,10 @@ int mlx5e_open_rq(struct mlx5e_channel *c, struct mlx5e_params *params,
+ 	if (MLX5E_GET_PFLAG(params, MLX5E_PFLAG_SKB_XMIT_MORE))
+ 		__set_bit(MLX5E_RQ_STATE_SKB_XMIT_MORE, &c->rq.state);
+ 
++#ifdef DEV_NETMAP
++	mlx5e_netmap_configure_rx_ring(rq, rq->ix);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_destroy_rq:
 @@ -1261,6 +1288,9 @@ err_dealloc_rq:
  
  void mlx5e_activate_rq(struct mlx5e_rq *rq)

--- a/LINUX/final-patches/mellanox--mlx5--5.8
+++ b/LINUX/final-patches/mellanox--mlx5--5.8
@@ -1,0 +1,446 @@
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile
+index 2a88532..37d3415 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/Makefile
+@@ -6,12 +6,12 @@
+ 
+ subdir-ccflags-y += -I$(src)
+ 
+-obj-$(CONFIG_MLX5_CORE) += mlx5_core.o
++obj-$(CONFIG_MLX5_CORE) += mlx5_core$(NETMAP_DRIVER_SUFFIX).o
+ 
+ #
+ # mlx5 core basic
+ #
+-mlx5_core-y :=	main.o cmd.o debugfs.o fw.o eq.o uar.o pagealloc.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-y :=	main.o cmd.o debugfs.o fw.o eq.o uar.o pagealloc.o \
+ 		health.o mcg.o cq.o alloc.o port.o mr.o pd.o \
+ 		transobj.o vport.o sriov.o fs_cmd.o fs_core.o pci_irq.o \
+ 		fs_counters.o fs_ft_pool.o rl.o lag/lag.o lag/debugfs.o dev.o events.o wq.o lib/gid.o \
+@@ -21,11 +21,11 @@ mlx5_core-y :=	main.o cmd.o debugfs.o fw.o eq.o uar.o pagealloc.o \
+ 		diag/diag_cnt.o params.o fw_exp.o lib/tout.o eswitch_devlink_compat.o \
+ 		ecpf.o lib/aso.o
+ 
+-mlx5_core-y += compat.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-y += compat.o
+ #
+ # Netdev basic
+ #
+-mlx5_core-$(CONFIG_MLX5_CORE_EN) += en/rqt.o en/tir.o en/rss.o en/rx_res.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_CORE_EN) += en/rqt.o en/tir.o en/rss.o en/rx_res.o \
+ 		en/channels.o en_main.o en_common.o en_fs.o en_ethtool.o \
+ 		en_tx.o en_rx.o en_dim.o en_txrx.o en/xdp.o en_stats.o en_sysfs.o en_ecn.o\
+ 		en_selftest.o en/port.o en/monitor_stats.o en/health.o \
+@@ -37,14 +37,14 @@ mlx5_core-$(CONFIG_MLX5_CORE_EN) += en/rqt.o en/tir.o en/rss.o en/rx_res.o \
+ #
+ # Netdev extra
+ #
+-mlx5_core-$(CONFIG_MLX5_EN_ARFS)     += en_arfs.o
+-mlx5_core-$(CONFIG_MLX5_EN_RXNFC)    += en_fs_ethtool.o
+-mlx5_core-$(CONFIG_MLX5_CORE_EN_DCB) += en_dcbnl.o en/port_buffer.o
+-mlx5_core-$(CONFIG_PCI_HYPERV_INTERFACE) += en/hv_vhca_stats.o
+-mlx5_core-$(CONFIG_MLX5_ESWITCH)     += lag/mp.o lag/port_sel.o lib/geneve.o lib/port_tun.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_EN_ARFS)     += en_arfs.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_EN_RXNFC)    += en_fs_ethtool.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_CORE_EN_DCB) += en_dcbnl.o en/port_buffer.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_HYPERV_INTERFACE) += en/hv_vhca_stats.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_ESWITCH)     += lag/mp.o lag/port_sel.o lib/geneve.o lib/port_tun.o \
+ 					en_rep.o en/rep/bond.o en/mod_hdr.o \
+ 					en/mapping.o en/rep/meter.o en/rep/sysfs.o
+-mlx5_core-$(CONFIG_MLX5_CLS_ACT)     += en_tc.o en/rep/tc.o en/rep/neigh.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_CLS_ACT)     += en_tc.o en/rep/tc.o en/rep/neigh.o \
+ 					lib/fs_chains.o en/tc_tun.o \
+ 					esw/indir_table.o en/tc_tun_encap.o \
+ 					en/tc_tun_vxlan.o en/tc_tun_gre.o en/tc_tun_geneve.o \
+@@ -52,7 +52,7 @@ mlx5_core-$(CONFIG_MLX5_CLS_ACT)     += en_tc.o en/rep/tc.o en/rep/neigh.o \
+ 					en/tc/post_act.o en/tc/int_port.o \
+ 					en/tc/post_meter.o
+ 
+-mlx5_core-$(CONFIG_MLX5_CLS_ACT)     += en/tc/act/act.o en/tc/act/drop.o en/tc/act/trap.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_CLS_ACT)     += en/tc/act/act.o en/tc/act/drop.o en/tc/act/trap.o \
+ 					en/tc/act/accept.o en/tc/act/mark.o en/tc/act/goto.o \
+ 					en/tc/act/tun.o en/tc/act/csum.o en/tc/act/pedit.o \
+ 					en/tc/act/vlan.o en/tc/act/vlan_mangle.o en/tc/act/mpls.o \
+@@ -60,60 +60,60 @@ mlx5_core-$(CONFIG_MLX5_CLS_ACT)     += en/tc/act/act.o en/tc/act/drop.o en/tc/a
+ 					en/tc/act/ct.o en/tc/act/sample.o en/tc/act/ptype.o \
+ 					en/tc/act/redirect_ingress.o en/tc/act/prio.o en/tc/act/police.o
+ 
+-mlx5_core-$(CONFIG_MLX5_TC_CT)	     += en/tc_ct.o en/tc/ct_fs_dmfs.o en/tc/ct_fs_smfs.o
+-mlx5_core-$(CONFIG_MLX5_TC_SAMPLE)   += en/tc/sample.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_TC_CT)	     += en/tc_ct.o en/tc/ct_fs_dmfs.o en/tc/ct_fs_smfs.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_TC_SAMPLE)   += en/tc/sample.o
+ 
+ #
+ # Core extra
+ #
+-mlx5_core-$(CONFIG_MLX5_ESWITCH)   += eswitch.o eswitch_offloads.o eswitch_offloads_termtbl.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_ESWITCH)   += eswitch.o eswitch_offloads.o eswitch_offloads_termtbl.o \
+ 				      ecpf.o rdma.o esw/legacy.o esw/vf_meter.o \
+ 				      esw/debugfs.o esw/devlink_port.o esw/vporttbl.o esw/qos.o \
+ 				      esw/pet_offloads.o
+ 
+-mlx5_core-$(CONFIG_MLX5_ESWITCH)   += esw/acl/helper.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_ESWITCH)   += esw/acl/helper.o \
+ 				      esw/acl/egress_lgcy.o esw/acl/egress_ofld.o \
+ 				      esw/acl/ingress_lgcy.o esw/acl/ingress_ofld.o
+ 
+-mlx5_core-$(CONFIG_MLX5_BRIDGE)    += esw/bridge.o en/rep/bridge.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_BRIDGE)    += esw/bridge.o en/rep/bridge.o
+ 
+-mlx5_core-$(CONFIG_MLX5_MPFS)      += lib/mpfs.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_MPFS)      += lib/mpfs.o
+ ifneq ($(CONFIG_VXLAN),)
+-	mlx5_core-y		+= lib/vxlan.o
++	mlx5_core$(NETMAP_DRIVER_SUFFIX)-y		+= lib/vxlan.o
+ endif
+ ifneq ($(CONFIG_PTP_1588_CLOCK),)
+-	mlx5_core-y		+= lib/clock.o
++	mlx5_core$(NETMAP_DRIVER_SUFFIX)-y		+= lib/clock.o
+ endif
+-mlx5_core-$(CONFIG_PCI_HYPERV_INTERFACE) += lib/hv.o lib/hv_vhca.o
+-mlx5_core-$(CONFIG_MLXDEVM) += mlx5_devm.o esw/devm_port.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_PCI_HYPERV_INTERFACE) += lib/hv.o lib/hv_vhca.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLXDEVM) += mlx5_devm.o esw/devm_port.o
+ 
+ #
+ # Ipoib netdev
+ #
+-mlx5_core-$(CONFIG_MLX5_CORE_IPOIB) += ipoib/ipoib.o ipoib/ethtool.o ipoib/ipoib_vlan.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_CORE_IPOIB) += ipoib/ipoib.o ipoib/ethtool.o ipoib/ipoib_vlan.o
+ 
+ #
+ # Accelerations & FPGA
+ #
+-mlx5_core-$(CONFIG_MLX5_IPSEC) += accel/ipsec_offload.o
+-mlx5_core-$(CONFIG_MLX5_FPGA_IPSEC) += fpga/ipsec.o
+-mlx5_core-$(CONFIG_MLX5_FPGA_TLS)   += fpga/tls.o
+-mlx5_core-$(CONFIG_MLX5_ACCEL)      += lib/crypto.o accel/tls.o accel/ipsec.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_IPSEC) += accel/ipsec_offload.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_FPGA_IPSEC) += fpga/ipsec.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_FPGA_TLS)   += fpga/tls.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_ACCEL)      += lib/crypto.o accel/tls.o accel/ipsec.o
+ 
+-mlx5_core-$(CONFIG_MLX5_FPGA) += fpga/cmd.o fpga/core.o fpga/conn.o fpga/sdk.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_FPGA) += fpga/cmd.o fpga/core.o fpga/conn.o fpga/sdk.o
+ 
+-mlx5_core-$(CONFIG_MLX5_EN_MACSEC) += en_accel/macsec.o en_accel/macsec_fs.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_EN_MACSEC) += en_accel/macsec.o en_accel/macsec_fs.o \
+ 				      en_accel/macsec_stats.o
+ 
+-mlx5_core-$(CONFIG_MLX5_EN_IPSEC) += en_accel/ipsec.o en_accel/ipsec_rxtx.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_EN_IPSEC) += en_accel/ipsec.o en_accel/ipsec_rxtx.o \
+ 				     en_accel/ipsec_stats.o en_accel/ipsec_fs.o esw/ipsec.o \
+ 				     en/ipsec_aso.o
+ 
+-mlx5_core-$(CONFIG_MLX5_EN_TLS) += en_accel/tls.o en_accel/tls_rxtx.o en_accel/tls_stats.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_EN_TLS) += en_accel/tls.o en_accel/tls_rxtx.o en_accel/tls_stats.o \
+ 				   en_accel/fs_tcp.o en_accel/ktls.o en_accel/ktls_txrx.o \
+ 				   en_accel/ktls_tx.o en_accel/ktls_rx.o
+ 
+-mlx5_core-$(CONFIG_MLX5_SW_STEERING) += steering/dr_domain.o steering/dr_table.o \
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_SW_STEERING) += steering/dr_domain.o steering/dr_table.o \
+ 					steering/dr_matcher.o steering/dr_rule.o \
+ 					steering/dr_icm_pool.o steering/dr_buddy.o \
+ 					steering/dr_ste.o steering/dr_send.o \
+@@ -125,14 +125,14 @@ mlx5_core-$(CONFIG_MLX5_SW_STEERING) += steering/dr_domain.o steering/dr_table.o
+ #
+ # SF device
+ #
+-mlx5_core-$(CONFIG_MLX5_SF) += sf/vhca_event.o sf/dev/dev.o sf/dev/driver.o irq_affinity.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_SF) += sf/vhca_event.o sf/dev/dev.o sf/dev/driver.o irq_affinity.o
+ 
+ #
+ # SF manager
+ #
+-mlx5_core-$(CONFIG_MLX5_SF_MANAGER) += sf/cmd.o sf/hw_table.o sf/devlink.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_SF_MANAGER) += sf/cmd.o sf/hw_table.o sf/devlink.o
+ 
+ #
+ ## SF cfg driver basic
+ #
+-mlx5_core-$(CONFIG_MLX5_SF_CFG) += sf/dev/cfg_driver.o
++mlx5_core$(NETMAP_DRIVER_SUFFIX)-$(CONFIG_MLX5_SF_CFG) += sf/dev/cfg_driver.o
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
+index e1cd67b..d9f90b6 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
+@@ -18,6 +18,10 @@ static int mlx5e_wait_for_sq_flush(struct mlx5e_txqsq *sq)
+ 			return 0;
+ 
+ 		msleep(20);
++#ifdef DEV_NETMAP
++		if (nm_netmap_on(NA(sq->txq->dev))) // TODO
++			mlx5e_netmap_tx_flush(sq); /* handle any CQEs */
++#endif
+ 	}
+ 
+ 	netdev_err(sq->netdev,
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+index 03f309e..37a8368 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_main.c
+@@ -88,8 +88,22 @@
+ #include "fpga/ipsec.h"
+ #include "compat.h"
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++/*
++ * mlx5_netmap_linux.h contains functions for netmap support
++ * that extend the standard driver.
++ */
++#define NETMAP_MLX5_MAIN
++#define DEV_NETMAP
++#include "mlx5_netmap_linux.h"
++#endif
++
+ bool mlx5e_check_fragmented_striding_rq_cap(struct mlx5_core_dev *mdev)
+ {
++#ifdef DEV_NETMAP
++	return 0;
++#endif
++
+ 	bool striding_rq_umr, inline_umr;
+ 	u16 max_wqe_sz_cap;
+ 
+@@ -1239,6 +1253,12 @@ int mlx5e_wait_for_min_rx_wqes(struct mlx5e_rq *rq, int wait_time)
+ {
+ 	unsigned long exp_time = jiffies + msecs_to_jiffies(wait_time);
+ 
++#ifdef DEV_NETMAP
++	struct netmap_adapter *na = NA(rq->netdev);
++	if (nm_netmap_on(na) && na->rx_rings[rq->ix]->nr_mode == NKR_NETMAP_ON)
++		return 0; /* no need to wait when netmap has built wqes */
++#endif
++
+ 	u16 min_wqes = mlx5_min_rx_wqes(rq->wq_type, mlx5e_rqwq_get_size(rq));
+ 
+ 	do {
+@@ -1321,6 +1341,10 @@ void mlx5e_free_rx_descs(struct mlx5e_rq *rq)
+ 
+ 		while (!mlx5_wq_cyc_is_empty(wq)) {
+ 			wqe_ix = mlx5_wq_cyc_get_tail(wq);
++#ifdef DEV_NETMAP
++			struct netmap_adapter *na = NA(rq->netdev);
++			if (!nm_netmap_on(na) || na->rx_rings[rq->ix]->nr_mode == NKR_NETMAP_OFF)
++#endif
+ 			rq->dealloc_wqe(rq, wqe_ix);
+ 			mlx5_wq_cyc_pop(wq);
+ 		}
+@@ -1458,6 +1482,10 @@ int mlx5e_open_rq(struct mlx5e_priv *priv, struct mlx5e_params *params,
+ 	if (MLX5E_GET_PFLAG(params, MLX5E_PFLAG_SKB_XMIT_MORE))
+ 		__set_bit(MLX5E_RQ_STATE_SKB_XMIT_MORE, &rq->state);
+ 
++#ifdef DEV_NETMAP
++	mlx5e_netmap_configure_rx_ring(rq, rq->ix);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_destroy_rq:
+@@ -1471,6 +1499,9 @@ err_dealloc_rq:
+ 
+ void mlx5e_activate_rq(struct mlx5e_rq *rq)
+ {
++#ifdef DEV_NETMAP
++	if (!nm_netmap_on(NA(rq->netdev)) || NA(rq->netdev)->rx_rings[rq->ix]->nr_mode == NKR_NETMAP_OFF)
++#endif
+ 	set_bit(MLX5E_RQ_STATE_ENABLED, &rq->state);
+ }
+ 
+@@ -1765,6 +1796,11 @@ static int mlx5e_alloc_txqsq(struct mlx5e_channel *c,
+ 	INIT_WORK(&sq->dim_obj.dim.work, mlx5e_tx_dim_work);
+ 	sq->dim_obj.dim.mode = params->tx_cq_moderation.cq_period_mode;
+ 
++#ifdef DEV_NETMAP
++	if (mlx5e_netmap_configure_tx_ring(c->priv, txq_ix))
++		return 0;
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_sq_wq_destroy:
+@@ -1978,6 +2014,9 @@ void mlx5e_stop_txqsq(struct mlx5e_txqsq *sq)
+ 	mlx5e_tx_disable_queue(sq->txq);
+ 
+ 	/* last doorbell out, godspeed .. */
++#ifdef DEV_NETMAP
++	if (!nm_netmap_on(NA(sq->txq->dev))) // TODO
++#endif
+ 	if (mlx5e_wqc_has_room_for(wq, sq->cc, sq->pc, 1)) {
+ 		u16 pi = mlx5_wq_cyc_ctr2ix(wq, sq->pc);
+ 		struct mlx5e_tx_wqe *nop;
+@@ -1998,6 +2037,12 @@ void mlx5e_close_txqsq(struct mlx5e_txqsq *sq)
+ 
+ 	cancel_work_sync(&sq->dim_obj.dim.work);
+ 	cancel_work_sync(&sq->recover_work);
++
++#ifdef DEV_NETMAP
++	if (nm_netmap_on(NA(sq->txq->dev))) // TODO
++		mlx5e_netmap_tx_flush(sq); /* handle any CQEs */
++#endif
++
+ 	mlx5e_destroy_sq(mdev, sq->sqn);
+ 	if (sq->rate_limit) {
+ 		rl.rate = sq->rate_limit;
+@@ -3569,6 +3614,11 @@ int mlx5e_open_locked(struct net_device *netdev)
+ 		priv->profile->update_carrier(priv);
+ 
+ 	mlx5e_queue_update_stats(priv);
++
++#ifdef DEV_NETMAP
++        netmap_enable_all_rings(netdev); /* NOP if netmap not in use */
++#endif
++
+ 	return 0;
+ 
+ err_clear_state_opened_flag:
+@@ -3604,6 +3654,10 @@ int mlx5e_close_locked(struct net_device *netdev)
+ 	mlx5e_apply_traps(priv, false);
+ 	clear_bit(MLX5E_STATE_OPENED, &priv->state);
+ 
++#ifdef DEV_NETMAP
++       netmap_disable_all_rings(netdev);
++#endif
++
+ 	netif_carrier_off(priv->netdev);
+ 	if (!mlx5e_is_uplink_rep(priv) && !mlx5e_is_vport_rep(priv))
+ 		mlx5e_destroy_debugfs(priv);
+@@ -7279,6 +7333,10 @@ void mlx5e_destroy_netdev(struct mlx5e_priv *priv)
+ {
+ 	struct net_device *netdev = priv->netdev;
+ 
++#ifdef DEV_NETMAP
++       netmap_detach(netdev);
++#endif /* DEV_NETMAP */
++
+ 	mlx5e_priv_cleanup(priv);
+ 	free_netdev(netdev);
+ }
+@@ -7391,6 +7449,11 @@ static int mlx5e_probe(struct auxiliary_device *adev,
+ 
+ 	mlx5e_dcbnl_init_app(priv);
+ 	mlx5_uplink_netdev_set(mdev, netdev);
++
++#ifdef DEV_NETMAP
++       mlx5e_netmap_attach(priv);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_unregister_netdev:
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
+index 7ac3a9d..c077d87 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
+@@ -94,6 +94,14 @@ const struct mlx5e_rx_handlers mlx5e_rx_handlers_nic = {
+ #endif
+ };
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++/*
++ * mlx5_netmap_linux.h contains functions for netmap support
++ * that extend the standard driver.
++ */
++#include "mlx5_netmap_linux.h"
++#endif
++
+ static inline bool mlx5e_rx_hw_stamp(struct hwtstamp_config *config)
+ {
+ 	return config->rx_filter == HWTSTAMP_FILTER_ALL;
+@@ -228,7 +236,7 @@ static inline u32 mlx5e_decompress_cqes_cont(struct mlx5e_rq *rq,
+ 	return cqe_count;
+ }
+ 
+-static inline u32 mlx5e_decompress_cqes_start(struct mlx5e_rq *rq,
++u32 mlx5e_decompress_cqes_start(struct mlx5e_rq *rq,
+ 					      struct mlx5_cqwq *wq,
+ 					      int budget_rem)
+ {
+@@ -2598,6 +2606,13 @@ int mlx5e_poll_rx_cq(struct mlx5e_cq *cq, int budget)
+ 		priv = netdev_priv(rq->netdev);
+ #endif
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++	int dummy;
++	int nm_irq = netmap_rx_irq(rq->netdev, rq->ix, &dummy);
++	if (nm_irq != NM_IRQ_PASS)
++		return (nm_irq == NM_IRQ_RESCHED) ? budget : 1;
++#endif
++
+ 	if (unlikely(!test_bit(MLX5E_RQ_STATE_ENABLED, &rq->state)))
+ 		return 0;
+ 
+diff --git a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_tx.c b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_tx.c
+index 20a529b..2c532db 100644
+--- a/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_tx.c
++++ b/mlx5/drivers/net/ethernet/mellanox/mlx5/core/en_tx.c
+@@ -43,6 +43,14 @@
+ #include "en/ptp.h"
+ #include <uapi/linux/pkt_sched.h>
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++/*
++ * mlx5_netmap_linux.h contains functions for netmap support
++ * that extend the standard driver.
++ */
++#include "mlx5_netmap_linux.h"
++#endif
++
+ static inline void mlx5e_read_cqe_slot(struct mlx5_cqwq *wq,
+ 				       u32 cqcc, void *data)
+ {
+@@ -996,6 +1004,11 @@ bool mlx5e_poll_tx_cq(struct mlx5e_cq *cq, int napi_budget)
+ 
+ 	sq = container_of(cq, struct mlx5e_txqsq, cq);
+ 
++#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++	if (netmap_tx_irq(sq->netdev, sq->ch_ix) != NM_IRQ_PASS)
++		return false;
++#endif
++
+ 	if (unlikely(!test_bit(MLX5E_SQ_STATE_ENABLED, &sq->state)))
+ 		return false;
+ 
+@@ -1118,23 +1131,29 @@ void mlx5e_free_txqsq_descs(struct mlx5e_txqsq *sq)
+ 
+ 		sqcc += wi->num_wqebbs;
+ 
+-		if (likely(wi->skb)) {
+-			mlx5e_tx_wi_dma_unmap(sq, wi, &dma_fifo_cc);
+-			dev_kfree_skb_any(wi->skb);
++		if (!nm_netmap_on(NA(sq->txq->dev))) {
++			/* do not free skbs in netmap mode */
++			if (likely(wi->skb)) {
++				mlx5e_tx_wi_dma_unmap(sq, wi, &dma_fifo_cc);
++				dev_kfree_skb_any(wi->skb);
+ 
+-			npkts++;
+-			nbytes += wi->num_bytes;
+-			continue;
+-		}
++				npkts++;
++				nbytes += wi->num_bytes;
++				continue;
++			}
+ 
+-		if (unlikely(mlx5e_ktls_tx_try_handle_resync_dump_comp(sq, wi, &dma_fifo_cc)))
+-			continue;
++			if (unlikely(mlx5e_ktls_tx_try_handle_resync_dump_comp(sq, wi, &dma_fifo_cc)))
++				continue;
+ 
+-		if (wi->num_fifo_pkts) {
+-			mlx5e_tx_wi_dma_unmap(sq, wi, &dma_fifo_cc);
+-			mlx5e_tx_wi_kfree_fifo_skbs(sq, wi);
++			if (wi->num_fifo_pkts) {
++				mlx5e_tx_wi_dma_unmap(sq, wi, &dma_fifo_cc);
++				mlx5e_tx_wi_kfree_fifo_skbs(sq, wi);
+ 
+-			npkts += wi->num_fifo_pkts;
++				npkts += wi->num_fifo_pkts;
++				nbytes += wi->num_bytes;
++			}
++		} else {
++			npkts++;
+ 			nbytes += wi->num_bytes;
+ 		}
+ 	}

--- a/LINUX/mlx5_netmap_linux.h
+++ b/LINUX/mlx5_netmap_linux.h
@@ -711,7 +711,7 @@ void mlx5e_netmap_attach(struct NM_MLX5E_ADAPTER *adapter) {
   na.nm_config = mlx5e_netmap_config;
 
   /* each channel has 1 rx ring and a tx for each tc */
-  na.num_tx_rings = adapter->channels.params.num_channels * adapter->channels.params.num_tc;
+  na.num_tx_rings = adapter->channels.params.num_channels * adapter->channels.params.mqprio.num_tc;
   na.num_rx_rings = adapter->channels.params.num_channels;
   na.rx_buf_maxsize = 1500; /* will be overwritten by nm_config */
   netmap_attach(&na);


### PR DESCRIPTION
* An old bugfix was missed in driver version 5.3.  I've had this patch for 2 years and I think I tested it at the time but we have moved past that version.
* I discovered that mellanox/nvidia provide a smaller tarball we can download to build netmap that does not bundle large debs.  This smaller tarball has the same sha256sum as the first inner tarball of the larger one.
* We are starting to test driver version 5.8 but early tests show no obvious problems with TX or RX.  If others want to test it please do.
* We use dkms to package but never shared the "recipe".