### PR TITLE
Cast the network_adapter pointer when saving in ax25_ptr

### DIFF
--- a/LINUX/bsd_glue.h
+++ b/LINUX/bsd_glue.h
@@ -300,7 +300,7 @@ struct thread;
  * for netmap-capable is some magic in the area pointed by that.
  */
 #define if_setnetmapadapter(_ifp, _na)	do { 				\
-	(_ifp)->ax25_ptr = _na;						\
+	(_ifp)->ax25_ptr = (void *)_na;					\
 } while (0)
 #define if_getnetmapadapter(_ifp)	((struct netmap_adapter *)(_ifp)->ax25_ptr)
 


### PR DESCRIPTION
This was reported in issue #972 and also seen by me upgrading from kernel 6.1.0-31-amd64 to 6.1.0-32-amd64 on Debian 12. The `netmap.ko` driver fails to compile because the `struct net_device` member `ax25_ptr` was modified in Linux kernel commit [7705d8a7f2c2](https://web.git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.6.y&id=7705d8a7f2c26c80973c81093db07c6022b2b30e) and is now type `struct ax25_dev *` not `void *` causing the assignment of `struct network_adapter *` to fail.

This MR casts `struct network_adapter *` to `(void *)` before assigning to `ax25_ptr`. My build and test with `pkt-gen` both work after this modification. Many thanks to the issue creator for finding the exact upstream commit.