### PR TITLE
linux: veth: fix kernel oops in multiqueue mode

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -1225,8 +1225,8 @@ out:
 EXPORT_SYMBOL(netmap_rings_config_get);
 
 /* Default nm_config implementation for netmap_hw_adapter on Linux. */
-static int
-netmap_linux_config(struct netmap_adapter *na, struct nm_config_info *info)
+int
+nm_os_config(struct netmap_adapter *na, struct nm_config_info *info)
 {
 	int ret = netmap_rings_config_get(na, info);
 
@@ -1239,6 +1239,7 @@ netmap_linux_config(struct netmap_adapter *na, struct nm_config_info *info)
 
 	return 0;
 }
+EXPORT_SYMBOL(nm_os_config);
 
 /* ######################## FILE OPERATIONS ####################### */
 
@@ -2559,7 +2560,7 @@ nm_os_onattach(struct ifnet *ifp)
 #endif /* NETMAP_LINUX_HAVE_SET_CHANNELS */
 #endif /* NETMAP_LINUX_HAVE_AX25PTR */
 	if (na->nm_config == NULL) {
-		hwna->up.nm_config = netmap_linux_config;
+		hwna->up.nm_config = nm_os_config;
 	}
 }
 

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -1783,6 +1783,8 @@ netmap_reload_map(struct netmap_adapter *na,
 
 #else /* linux */
 
+int nm_os_config(struct netmap_adapter *na, struct nm_config_info *info);
+
 int nm_iommu_group_id(bus_dma_tag_t dev);
 #include <linux/dma-mapping.h>
 


### PR DESCRIPTION
Make the ring configuration identical at both veth endpoints.  
Oops can be reproduced with pkt-gen:
ip l a dev vetha type veth peer vethb  
ethtool -L vetha rx 4 tx 4  
pkt-get -f rx -i vetha  